### PR TITLE
HOTFIX: bug in search and paginator interaction

### DIFF
--- a/frontend/src/app/core/components/admin/faculty-pref/faculty-pref.component.html
+++ b/frontend/src/app/core/components/admin/faculty-pref/faculty-pref.component.html
@@ -137,10 +137,11 @@
       <!-- Table Paginator -->
       <mat-paginator
         class="custom-paginator"
-        [length]="dataSource.data.length"
+        [length]="filteredData.length"
         [pageSize]="10"
         [pageSizeOptions]="[5, 10, 25, 50, 100]"
         [showFirstLastButtons]="true"
+        (page)="updateDisplayedData()"
         aria-label="Select page"
       >
       </mat-paginator>


### PR DESCRIPTION
I have overlooked a bug on how the search and pagination interacts with our `faculty-preferences table`. Since we are using both **search** and **pagination** to filter results, they're conflicting with each other, causing an error in either functionality. This PR addresses those bugs and solves these issues. Kindly test it further so we can spot any potential error that might still be present.