### PR TITLE
Add toggle publishing & get scheduling published API

### DIFF
--- a/backend/app/Http/Controllers/FacultyController.php
+++ b/backend/app/Http/Controllers/FacultyController.php
@@ -5,7 +5,9 @@ namespace App\Http\Controllers;
 use App\Models\Faculty;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\DB;
 use App\Mail\PreferencesSubmitted;
+use App\Models\ActiveSemester;
 class FacultyController extends Controller
 {
     public function getFaculty()
@@ -75,6 +77,7 @@ class FacultyController extends Controller
                     ->subject('Your Preferences Have Been Submitted and Are Under Review');
         });
     }
+
     public function sendSubjectsScheduleSetEmail(Request $request)
     {
         $facultyId = $request->input('faculty_id');
@@ -101,4 +104,225 @@ class FacultyController extends Controller
                     ->subject('Your Subjects, Load, and Schedule Have Been Set');
         });
     }
+
+    public function getIndividualFacultySchedule(Request $request)
+    {
+        // Step 1: Validate the input to ensure faculty_id is provided
+        $request->validate([
+            'faculty_id' => 'required|integer|exists:faculty,id',
+        ]);
+    
+        $facultyId = $request->input('faculty_id');
+    
+        // Step 2: Retrieve the current active semester with academic year details
+        $activeSemester = DB::table('active_semesters')
+            ->join('academic_years', 'active_semesters.academic_year_id', '=', 'academic_years.academic_year_id')
+            ->where('active_semesters.is_active', 1)
+            ->select(
+                'active_semesters.active_semester_id',
+                'active_semesters.semester_id',
+                'academic_years.academic_year_id',
+                'academic_years.year_start',
+                'academic_years.year_end'
+            )
+            ->first();
+    
+        if (!$activeSemester) {
+            return response()->json(['message' => 'No active semester found.'], 404);
+        }
+    
+        // Step 3: Check if the schedule is published for this faculty
+        $publicationStatus = DB::table('faculty_schedule_publication')
+            ->where('faculty_id', $facultyId)
+            ->where('is_published', 1)
+            ->exists();
+    
+        if (!$publicationStatus) {
+            return response()->json([
+                'message' => 'Schedules are still being prepared. Please wait while they are being finalized.'
+            ], 200);
+        }
+    
+        // Step 4: Fetch the faculty information
+        $faculty = DB::table('faculty')
+            ->join('users', 'faculty.user_id', '=', 'users.id')
+            ->where('faculty.id', $facultyId)
+            ->select(
+                'faculty.id as faculty_id',
+                'users.name as faculty_name',
+                'faculty.faculty_type',
+                DB::raw('0 as assigned_units'),
+                DB::raw('0 as is_published')
+            )
+            ->first();
+    
+        if (!$faculty) {
+            return response()->json(['message' => 'Faculty not found'], 404);
+        }
+    
+        // Step 5: Get the schedules for the specific faculty
+        $facultySchedules = $this->getFacultySchedules($faculty->faculty_id, $activeSemester);
+    
+        // Step 6: Prepare the response structure
+        $response = [
+            'faculty_schedule_report' => [
+                'academic_year_id' => $activeSemester->academic_year_id,
+                'year_start' => $activeSemester->year_start,
+                'year_end' => $activeSemester->year_end,
+                'active_semester_id' => $activeSemester->active_semester_id,
+                'semester' => $activeSemester->semester_id,
+                'faculty' => [
+                    'faculty_id' => $faculty->faculty_id,
+                    'faculty_name' => $faculty->faculty_name,
+                    'faculty_type' => $faculty->faculty_type,
+                    'schedules' => $facultySchedules
+                ]
+            ]
+        ];
+    
+        return response()->json($response);
+    }
+    
+
+    private function getFacultySchedules($facultyId, $activeSemester)
+    {
+        $schedules = DB::table('schedules')
+            ->join('section_courses', 'schedules.section_course_id', '=', 'section_courses.section_course_id')
+            ->join('course_assignments', 'section_courses.course_assignment_id', '=', 'course_assignments.course_assignment_id')
+            ->join('courses', 'course_assignments.course_id', '=', 'courses.course_id')
+            ->join('sections_per_program_year', 'section_courses.sections_per_program_year_id', '=', 'sections_per_program_year.sections_per_program_year_id')
+            ->join('programs', 'sections_per_program_year.program_id', '=', 'programs.program_id')
+            ->leftJoin('rooms', 'schedules.room_id', '=', 'rooms.room_id') // Use leftJoin to allow null room values
+            ->join('semesters as s', 'course_assignments.semester_id', '=', 's.semester_id')
+            ->where('schedules.faculty_id', $facultyId)
+            ->where('s.semester', $activeSemester->semester_id)
+            ->where('sections_per_program_year.academic_year_id', $activeSemester->academic_year_id)
+            ->select(
+                'programs.program_id',
+                'programs.program_code',
+                'programs.program_title',
+                'sections_per_program_year.year_level',
+                'sections_per_program_year.sections_per_program_year_id',
+                'sections_per_program_year.section_name',
+                'schedules.schedule_id',
+                'schedules.day',
+                'schedules.start_time',
+                'schedules.end_time',
+                'rooms.room_code',
+                'course_assignments.course_assignment_id',
+                'courses.course_title',
+                'courses.course_code',
+                'courses.lec_hours as lec',
+                'courses.lab_hours as lab',
+                'courses.units',
+                'courses.tuition_hours',
+                's.semester_id'
+            )
+            ->get();
+    
+        $organizedSchedules = [];
+    
+        foreach ($schedules as $schedule) {
+            $programIndex = $this->findOrCreateProgram($organizedSchedules, $schedule);
+            $yearLevelIndex = $this->findOrCreateYearLevel($organizedSchedules[$programIndex]['year_levels'], $schedule);
+            $semesterIndex = $this->findOrCreateSemester($organizedSchedules[$programIndex]['year_levels'][$yearLevelIndex]['semesters'], $schedule->semester_id);
+            $sectionIndex = $this->findOrCreateSection($organizedSchedules[$programIndex]['year_levels'][$yearLevelIndex]['semesters'][$semesterIndex]['sections'], $schedule);
+    
+            // Ensure N/A values for potentially missing fields
+            $startTime = $schedule->start_time ?? 'N/A';
+            $endTime = $schedule->end_time ?? 'N/A';
+            $roomCode = $schedule->room_code ?? 'N/A';
+    
+            if (!isset($organizedSchedules[$programIndex]['year_levels'][$yearLevelIndex]['semesters'][$semesterIndex]['sections'][$sectionIndex]['courses'][$schedule->day])) {
+                $organizedSchedules[$programIndex]['year_levels'][$yearLevelIndex]['semesters'][$semesterIndex]['sections'][$sectionIndex]['courses'][$schedule->day] = [];
+            }
+    
+            $organizedSchedules[$programIndex]['year_levels'][$yearLevelIndex]['semesters'][$semesterIndex]['sections'][$sectionIndex]['courses'][$schedule->day][] = [
+                'schedule_id' => $schedule->schedule_id,
+                'start_time' => $startTime,
+                'end_time' => $endTime,
+                'room_code' => $roomCode,
+                'course_details' => [
+                    'course_assignment_id' => $schedule->course_assignment_id ?? 'N/A',
+                    'course_title' => $schedule->course_title ?? 'N/A',
+                    'course_code' => $schedule->course_code ?? 'N/A',
+                    'lec' => $schedule->lec ?? 0,
+                    'lab' => $schedule->lab ?? 0,
+                    'units' => $schedule->units ?? 0,
+                    'tuition_hours' => $schedule->tuition_hours ?? 0
+                ]
+            ];
+        }
+    
+        return array_values($organizedSchedules);
+    }
+    
+
+    private function findOrCreateProgram(&$programs, $schedule)
+    {
+        foreach ($programs as $index => $program) {
+            if ($program['program_id'] == $schedule->program_id) {
+                return $index;
+            }
+        }
+
+        $programs[] = [
+            'program_id' => $schedule->program_id,
+            'program_code' => $schedule->program_code,
+            'program_title' => $schedule->program_title,
+            'year_levels' => []
+        ];
+
+        return count($programs) - 1;
+    }
+
+    private function findOrCreateYearLevel(&$yearLevels, $schedule)
+    {
+        foreach ($yearLevels as $index => $yearLevel) {
+            if ($yearLevel['year_level'] == $schedule->year_level) {
+                return $index;
+            }
+        }
+
+        $yearLevels[] = [
+            'year_level' => $schedule->year_level,
+            'semesters' => []
+        ];
+
+        return count($yearLevels) - 1;
+    }
+
+    private function findOrCreateSemester(&$semesters, $semesterId)
+    {
+        foreach ($semesters as $index => $semester) {
+            if ($semester['semester'] == $semesterId) {
+                return $index;
+            }
+        }
+
+        $semesters[] = [
+            'semester' => $semesterId,
+            'sections' => []
+        ];
+
+        return count($semesters) - 1;
+    }
+
+    private function findOrCreateSection(&$sections, $schedule)
+    {
+        foreach ($sections as $index => $section) {
+            if ($section['section_per_program_year_id'] == $schedule->sections_per_program_year_id) {
+                return $index;
+            }
+        }
+
+        $sections[] = [
+            'section_per_program_year_id' => $schedule->sections_per_program_year_id,
+            'section_name' => $schedule->section_name,
+            'courses' => []
+        ];
+
+        return count($sections) - 1;
+    }
+    
 }

--- a/backend/app/Http/Controllers/ReportsController.php
+++ b/backend/app/Http/Controllers/ReportsController.php
@@ -8,45 +8,80 @@ use App\Models\ActiveSemester;
 
 class ReportsController extends Controller
 {
-    public function getFacultySchedulesReport()
+
+    public function getFacultyScheduleReports()
     {
-        // Step 1: Retrieve the current active semester with academic year details
+        // Step 1: Get the active semester and academic year
         $activeSemester = DB::table('active_semesters')
             ->join('academic_years', 'active_semesters.academic_year_id', '=', 'academic_years.academic_year_id')
             ->where('active_semesters.is_active', 1)
             ->select(
-                'active_semesters.active_semester_id',
-                'active_semesters.semester_id',
-                'academic_years.academic_year_id',
+                'active_semesters.*',
                 'academic_years.year_start',
                 'academic_years.year_end'
             )
             ->first();
-    
+
         if (!$activeSemester) {
-            return response()->json(['message' => 'No active semester found.'], 404);
+            return response()->json(['message' => 'No active semester found'], 404);
         }
-    
-        // Step 2: Get all faculty schedules with course details, including faculty without schedules
-        $facultySchedules = DB::table('faculty')
+
+        $activeAcademicYearId = $activeSemester->academic_year_id;
+
+        $faculties = DB::table('faculty')
             ->join('users', 'faculty.user_id', '=', 'users.id')
-            ->leftJoin('schedules', 'schedules.faculty_id', '=', 'faculty.id')
-            ->leftJoin('section_courses', 'section_courses.section_course_id', '=', 'schedules.section_course_id')
-            ->leftJoin('sections_per_program_year', function ($join) use ($activeSemester) {
-                $join->on('sections_per_program_year.sections_per_program_year_id', '=', 'section_courses.sections_per_program_year_id')
-                     ->where('sections_per_program_year.academic_year_id', '=', $activeSemester->academic_year_id);
-            })
-            ->leftJoin('course_assignments', function ($join) use ($activeSemester) {
-                $join->on('course_assignments.course_assignment_id', '=', 'section_courses.course_assignment_id')
-                     ->where('course_assignments.semester_id', '=', $activeSemester->semester_id);
-            })
-            ->leftJoin('courses', 'courses.course_id', '=', 'course_assignments.course_id')
-            ->leftJoin('rooms', 'rooms.room_id', '=', 'schedules.room_id')
             ->select(
                 'faculty.id as faculty_id',
                 'users.name as faculty_name',
-                'users.code as faculty_code',
                 'faculty.faculty_type',
+                DB::raw('0 as assigned_units'),
+                DB::raw('0 as is_published')
+            )
+            ->get();
+
+        $response = [
+            'faculty_schedule_reports' => [
+                'academic_year_id' => $activeSemester->academic_year_id,
+                'year_start' => $activeSemester->year_start,
+                'year_end' => $activeSemester->year_end,
+                'active_semester_id' => $activeSemester->active_semester_id,
+                'semester' => $activeSemester->semester_id,
+                'faculties' => []
+            ]
+        ];
+
+        foreach ($faculties as $faculty) {
+            $facultySchedules = $this->getFacultySchedules($faculty->faculty_id, $activeSemester);
+
+            if (!empty($facultySchedules)) {
+                $faculty->schedules = $facultySchedules;
+                $response['faculty_schedule_reports']['faculties'][] = $faculty;
+            }
+        }
+
+        return response()->json($response);
+    }
+
+    private function getFacultySchedules($facultyId, $activeSemester)
+    {
+        $schedules = DB::table('schedules')
+            ->join('section_courses', 'schedules.section_course_id', '=', 'section_courses.section_course_id')
+            ->join('course_assignments', 'section_courses.course_assignment_id', '=', 'course_assignments.course_assignment_id')
+            ->join('courses', 'course_assignments.course_id', '=', 'courses.course_id')
+            ->join('sections_per_program_year', 'section_courses.sections_per_program_year_id', '=', 'sections_per_program_year.sections_per_program_year_id')
+            ->join('programs', 'sections_per_program_year.program_id', '=', 'programs.program_id')
+            ->join('rooms', 'schedules.room_id', '=', 'rooms.room_id')
+            ->join('semesters as s', 'course_assignments.semester_id', '=', 's.semester_id') // Adjusted join for semester
+            ->where('schedules.faculty_id', $facultyId)
+            ->where('s.semester', $activeSemester->semester_id) // Filter using the semester's attribute
+            ->where('sections_per_program_year.academic_year_id', $activeSemester->academic_year_id) // Ensure it's for the active academic year
+            ->select(
+                'programs.program_id',
+                'programs.program_code',
+                'programs.program_title',
+                'sections_per_program_year.year_level',
+                'sections_per_program_year.sections_per_program_year_id',
+                'sections_per_program_year.section_name',
                 'schedules.schedule_id',
                 'schedules.day',
                 'schedules.start_time',
@@ -55,62 +90,220 @@ class ReportsController extends Controller
                 'course_assignments.course_assignment_id',
                 'courses.course_title',
                 'courses.course_code',
-                'courses.lec_hours',
-                'courses.lab_hours',
+                'courses.lec_hours as lec',
+                'courses.lab_hours as lab',
                 'courses.units',
                 'courses.tuition_hours',
-                'schedules.is_published'
+                's.semester_id' // Include the semester_id in the select statement
             )
             ->get();
     
-        // Step 3: Group the data by faculty and structure schedules
-        $faculties = [];
+        $organizedSchedules = [];
     
-        foreach ($facultySchedules as $schedule) {
-            if (!isset($faculties[$schedule->faculty_id])) {
-                $faculties[$schedule->faculty_id] = [
-                    'faculty_id' => $schedule->faculty_id,
-                    'faculty_name' => $schedule->faculty_name,
-                    'faculty_code' => $schedule->faculty_code,
-                    'faculty_type' => $schedule->faculty_type,
-                    'assigned_units' => 0,
-                    'is_published' => $schedule->is_published,
-                    'schedules' => []
-                ];
+        foreach ($schedules as $schedule) {
+            // Access semester_id safely here
+            $programIndex = $this->findOrCreateProgram($organizedSchedules, $schedule);
+            $yearLevelIndex = $this->findOrCreateYearLevel($organizedSchedules[$programIndex]['year_levels'], $schedule);
+            $semesterIndex = $this->findOrCreateSemester($organizedSchedules[$programIndex]['year_levels'][$yearLevelIndex]['semesters'], $schedule->semester_id);
+            $sectionIndex = $this->findOrCreateSection($organizedSchedules[$programIndex]['year_levels'][$yearLevelIndex]['semesters'][$semesterIndex]['sections'], $schedule);
+    
+            if (!isset($organizedSchedules[$programIndex]['year_levels'][$yearLevelIndex]['semesters'][$semesterIndex]['sections'][$sectionIndex]['courses'][$schedule->day])) {
+                $organizedSchedules[$programIndex]['year_levels'][$yearLevelIndex]['semesters'][$semesterIndex]['sections'][$sectionIndex]['courses'][$schedule->day] = [];
             }
     
-            if ($schedule->course_assignment_id) {
-                $faculties[$schedule->faculty_id]['assigned_units'] += $schedule->units;
-    
-                $faculties[$schedule->faculty_id]['schedules'][] = [
-                    'schedule_id' => $schedule->schedule_id,
-                    'day' => $schedule->day,
-                    'start_time' => $schedule->start_time,
-                    'end_time' => $schedule->end_time,
-                    'room_code' => $schedule->room_code,
-                    'course_details' => [
-                        'course_assignment_id' => $schedule->course_assignment_id,
-                        'course_title' => $schedule->course_title,
-                        'course_code' => $schedule->course_code,
-                        'lec' => $schedule->lec_hours,
-                        'lab' => $schedule->lab_hours,
-                        'units' => $schedule->units,
-                        'tuition_hours' => $schedule->tuition_hours
-                    ]
-                ];
-            }
+            $organizedSchedules[$programIndex]['year_levels'][$yearLevelIndex]['semesters'][$semesterIndex]['sections'][$sectionIndex]['courses'][$schedule->day][] = [
+                'schedule_id' => $schedule->schedule_id,
+                'start_time' => $schedule->start_time,
+                'end_time' => $schedule->end_time,
+                'room_code' => $schedule->room_code,
+                'course_details' => [
+                    'course_assignment_id' => $schedule->course_assignment_id,
+                    'course_title' => $schedule->course_title,
+                    'course_code' => $schedule->course_code,
+                    'lec' => $schedule->lec,
+                    'lab' => $schedule->lab,
+                    'units' => $schedule->units,
+                    'tuition_hours' => $schedule->tuition_hours
+                ]
+            ];
         }
     
-        // Step 4: Structure the response
-        return response()->json([
-            'faculty_schedule_reports' => [
-                'academic_year_id' => $activeSemester->academic_year_id,
-                'year_start' => $activeSemester->year_start,
-                'year_end' => $activeSemester->year_end,
-                'active_semester_id' => $activeSemester->active_semester_id,
-                'semester' => $activeSemester->semester_id,
-                'faculties' => array_values($faculties)
-            ]
-        ]);
+        return array_values($organizedSchedules);
     }
+    
+
+    private function findOrCreateProgram(&$programs, $schedule)
+    {
+        foreach ($programs as $index => $program) {
+            if ($program['program_id'] == $schedule->program_id) {
+                return $index;
+            }
+        }
+
+        $programs[] = [
+            'program_id' => $schedule->program_id,
+            'program_code' => $schedule->program_code,
+            'program_title' => $schedule->program_title,
+            'year_levels' => []
+        ];
+
+        return count($programs) - 1;
+    }
+
+    private function findOrCreateYearLevel(&$yearLevels, $schedule)
+    {
+        foreach ($yearLevels as $index => $yearLevel) {
+            if ($yearLevel['year_level'] == $schedule->year_level) {
+                return $index;
+            }
+        }
+
+        $yearLevels[] = [
+            'year_level' => $schedule->year_level,
+            'semesters' => []
+        ];
+
+        return count($yearLevels) - 1;
+    }
+
+    private function findOrCreateSemester(&$semesters, $semesterId)
+    {
+        foreach ($semesters as $index => $semester) {
+            if ($semester['semester'] == $semesterId) {
+                return $index;
+            }
+        }
+
+        $semesters[] = [
+            'semester' => $semesterId,
+            'sections' => []
+        ];
+
+        return count($semesters) - 1;
+    }
+
+    private function findOrCreateSection(&$sections, $schedule)
+    {
+        foreach ($sections as $index => $section) {
+            if ($section['section_per_program_year_id'] == $schedule->sections_per_program_year_id) {
+                return $index;
+            }
+        }
+
+        $sections[] = [
+            'section_per_program_year_id' => $schedule->sections_per_program_year_id,
+            'section_name' => $schedule->section_name,
+            'courses' => []
+        ];
+
+        return count($sections) - 1;
+    }
+    // public function getFacultySchedulesReport()
+    // {
+    //     // Step 1: Retrieve the current active semester with academic year details
+    //     $activeSemester = DB::table('active_semesters')
+    //         ->join('academic_years', 'active_semesters.academic_year_id', '=', 'academic_years.academic_year_id')
+    //         ->where('active_semesters.is_active', 1)
+    //         ->select(
+    //             'active_semesters.active_semester_id',
+    //             'active_semesters.semester_id',
+    //             'academic_years.academic_year_id',
+    //             'academic_years.year_start',
+    //             'academic_years.year_end'
+    //         )
+    //         ->first();
+    
+    //     if (!$activeSemester) {
+    //         return response()->json(['message' => 'No active semester found.'], 404);
+    //     }
+    
+    //     // Step 2: Get all faculty schedules with course details, including faculty without schedules
+    //     $facultySchedules = DB::table('faculty')
+    //         ->join('users', 'faculty.user_id', '=', 'users.id')
+    //         ->leftJoin('schedules', 'schedules.faculty_id', '=', 'faculty.id')
+    //         ->leftJoin('section_courses', 'section_courses.section_course_id', '=', 'schedules.section_course_id')
+    //         ->leftJoin('sections_per_program_year', function ($join) use ($activeSemester) {
+    //             $join->on('sections_per_program_year.sections_per_program_year_id', '=', 'section_courses.sections_per_program_year_id')
+    //                  ->where('sections_per_program_year.academic_year_id', '=', $activeSemester->academic_year_id);
+    //         })
+    //         ->leftJoin('course_assignments', function ($join) use ($activeSemester) {
+    //             $join->on('course_assignments.course_assignment_id', '=', 'section_courses.course_assignment_id')
+    //                  ->where('course_assignments.semester_id', '=', $activeSemester->semester_id);
+    //         })
+    //         ->leftJoin('courses', 'courses.course_id', '=', 'course_assignments.course_id')
+    //         ->leftJoin('rooms', 'rooms.room_id', '=', 'schedules.room_id')
+    //         ->select(
+    //             'faculty.id as faculty_id',
+    //             'users.name as faculty_name',
+    //             'users.code as faculty_code',
+    //             'faculty.faculty_type',
+    //             'schedules.schedule_id',
+    //             'schedules.day',
+    //             'schedules.start_time',
+    //             'schedules.end_time',
+    //             'rooms.room_code',
+    //             'course_assignments.course_assignment_id',
+    //             'courses.course_title',
+    //             'courses.course_code',
+    //             'courses.lec_hours',
+    //             'courses.lab_hours',
+    //             'courses.units',
+    //             'courses.tuition_hours'
+    //         )
+    //         ->get();
+    
+    //     // Step 3: Group the data by faculty and structure schedules
+    //     $faculties = [];
+    
+    //     foreach ($facultySchedules as $schedule) {
+    //         if (!isset($faculties[$schedule->faculty_id])) {
+    //             $faculties[$schedule->faculty_id] = [
+    //                 'faculty_id' => $schedule->faculty_id,
+    //                 'faculty_name' => $schedule->faculty_name,
+    //                 'faculty_code' => $schedule->faculty_code,
+    //                 'faculty_type' => $schedule->faculty_type,
+    //                 'assigned_units' => 0,
+    //                 'is_published' => 0,
+    //                 'schedules' => []
+    //             ];
+    //         }
+    
+    //         if ($schedule->course_assignment_id) {
+    //             $faculties[$schedule->faculty_id]['assigned_units'] += $schedule->units;
+    
+    //             if ($schedule->schedule_id && $faculties[$schedule->faculty_id]['is_published'] == 0) {
+    //                 $faculties[$schedule->faculty_id]['is_published'] = 1;
+    //             }
+    
+    //             $faculties[$schedule->faculty_id]['schedules'][] = [
+    //                 'schedule_id' => $schedule->schedule_id,
+    //                 'day' => $schedule->day,
+    //                 'start_time' => $schedule->start_time,
+    //                 'end_time' => $schedule->end_time,
+    //                 'room_code' => $schedule->room_code,
+    //                 'course_details' => [
+    //                     'course_assignment_id' => $schedule->course_assignment_id,
+    //                     'course_title' => $schedule->course_title,
+    //                     'course_code' => $schedule->course_code,
+    //                     'lec' => $schedule->lec_hours,
+    //                     'lab' => $schedule->lab_hours,
+    //                     'units' => $schedule->units,
+    //                     'tuition_hours' => $schedule->tuition_hours
+    //                 ]
+    //             ];
+    //         }
+    //     }
+    
+    //     // Step 4: Structure the response
+    //     return response()->json([
+    //         'faculty_schedule_reports' => [
+    //             'academic_year_id' => $activeSemester->academic_year_id,
+    //             'year_start' => $activeSemester->year_start,
+    //             'year_end' => $activeSemester->year_end,
+    //             'active_semester_id' => $activeSemester->active_semester_id,
+    //             'semester' => $activeSemester->semester_id,
+    //             'faculties' => array_values($faculties)
+    //         ]
+    //     ]);
+    // }
 }

--- a/backend/app/Http/Controllers/SchedulingController.php
+++ b/backend/app/Http/Controllers/SchedulingController.php
@@ -137,5 +137,177 @@ class SchedulingController extends Controller
             return response()->json(['message' => 'Internal Server Error'], 500);
         }
     }
+
+    public function togglePublishSchedules(Request $request)
+    {
+        // Step 1: Get the active semester and academic year
+        $activeSemester = DB::table('active_semesters')
+            ->where('is_active', 1)
+            ->first();
+    
+        if (!$activeSemester) {
+            return response()->json(['message' => 'No active semester found'], 404);
+        }
+    
+        $activeAcademicYearId = $activeSemester->academic_year_id;
+        $activeSemesterId = $activeSemester->semester_id;
+    
+        // Step 2: Define the new `is_published` value (toggle between 0 and 1)
+        $isPublished = $request->input('is_published'); 
+    
+        // Step 3: Fetch schedule IDs for the active semester and academic year
+        $activeSchedules = DB::table('schedules')
+            ->select('schedules.schedule_id')
+            ->join('section_courses', 'schedules.section_course_id', '=', 'section_courses.section_course_id')
+            ->join('course_assignments', 'section_courses.course_assignment_id', '=', 'course_assignments.course_assignment_id')
+            ->join('sections_per_program_year', 'section_courses.sections_per_program_year_id', '=', 'sections_per_program_year.sections_per_program_year_id')
+            ->join('semesters', 'course_assignments.semester_id', '=', 'semesters.semester_id')
+            ->where('sections_per_program_year.academic_year_id', $activeAcademicYearId)
+            ->where('semesters.semester', $activeSemesterId)
+            ->pluck('schedules.schedule_id'); // Using `pluck` to get an array of schedule IDs
+    
+        // Step 4: Set `is_published` to 0 for all schedules not in the active academic year and semester
+        DB::table('schedules')
+            ->whereNotIn('schedule_id', $activeSchedules)
+            ->update(['is_published' => 0]);
+    
+        // Step 5: Set `is_published` to 0 for all entries in `faculty_schedule_publication` not in the active academic year and semester
+        DB::table('faculty_schedule_publication')
+            ->whereNotIn('schedule_id', $activeSchedules)
+            ->update(['is_published' => 0]);
+    
+        // Step 6: Update `is_published` for the fetched schedules in the `schedules` table
+        $updatedCount = DB::table('schedules')
+            ->whereIn('schedule_id', $activeSchedules)
+            ->update(['is_published' => $isPublished]);
+    
+        // Step 7: Update `is_published` in the `faculty_schedule_publication` table based on the same schedule IDs
+        DB::table('faculty_schedule_publication')
+            ->whereIn('schedule_id', $activeSchedules)
+            ->update(['is_published' => $isPublished]);
+    
+        // Step 8: Return a response
+        return response()->json([
+            'message' => 'Schedules and faculty schedule publications updated successfully',
+            'updated_count' => $updatedCount,
+            'is_published' => $isPublished,
+            'active_semester_id' => $activeSemester->active_semester_id,
+            'academic_year_id' => $activeAcademicYearId,
+            'semester_id' => $activeSemesterId
+        ]);
+    }
+    
+
+
+    public function toggleIndividualSchedule(Request $request)
+    {
+        // Step 1: Validate the input
+        $request->validate([
+            'faculty_id' => 'required|integer|exists:faculty_schedule_publication,faculty_id',
+            'is_published' => 'required|boolean'
+        ]);
+
+        $facultyId = $request->input('faculty_id');
+        $isPublished = $request->input('is_published');
+
+        // Step 2: Get the active semester and academic year
+        $activeSemester = DB::table('active_semesters')
+            ->where('is_active', 1)
+            ->first();
+
+        if (!$activeSemester) {
+            return response()->json(['message' => 'No active semester found'], 404);
+        }
+
+        $activeAcademicYearId = $activeSemester->academic_year_id;
+        $activeSemesterId = $activeSemester->semester_id;
+
+        // Step 3: Set `is_published` to 0 for all schedules not in the active semester and academic year
+        // This will ensure that schedules from previous semesters or academic years are deactivated.
+        DB::table('faculty_schedule_publication')
+            ->join('schedules', 'faculty_schedule_publication.schedule_id', '=', 'schedules.schedule_id')
+            ->join('section_courses', 'schedules.section_course_id', '=', 'section_courses.section_course_id')
+            ->join('course_assignments', 'section_courses.course_assignment_id', '=', 'course_assignments.course_assignment_id')
+            ->join('sections_per_program_year', 'section_courses.sections_per_program_year_id', '=', 'sections_per_program_year.sections_per_program_year_id')
+            ->join('semesters', 'course_assignments.semester_id', '=', 'semesters.semester_id')
+            ->where('faculty_schedule_publication.faculty_id', $facultyId)
+            ->where(function ($query) use ($activeAcademicYearId, $activeSemesterId) {
+                $query->where('sections_per_program_year.academic_year_id', '<>', $activeAcademicYearId)
+                    ->orWhere('semesters.semester', '<>', $activeSemesterId);
+            })
+            ->update(['faculty_schedule_publication.is_published' => 0, 'schedules.is_published' => 0, 'faculty_schedule_publication.updated_at' => now(), 'schedules.updated_at' => now()]);
+
+        // Step 4: Fetch all related schedule_ids from the faculty_schedule_publication table
+        // Only for schedules that match the active academic year and semester
+        $facultySchedules = DB::table('faculty_schedule_publication')
+            ->join('schedules', 'faculty_schedule_publication.schedule_id', '=', 'schedules.schedule_id')
+            ->join('section_courses', 'schedules.section_course_id', '=', 'section_courses.section_course_id')
+            ->join('course_assignments', 'section_courses.course_assignment_id', '=', 'course_assignments.course_assignment_id')
+            ->join('sections_per_program_year', 'section_courses.sections_per_program_year_id', '=', 'sections_per_program_year.sections_per_program_year_id')
+            ->join('semesters', 'course_assignments.semester_id', '=', 'semesters.semester_id')
+            ->where('faculty_schedule_publication.faculty_id', $facultyId)
+            ->where('sections_per_program_year.academic_year_id', $activeAcademicYearId)
+            ->where('semesters.semester', $activeSemesterId)
+            ->pluck('schedules.schedule_id', 'faculty_schedule_publication.faculty_schedule_publication_id');
+
+        if ($facultySchedules->isEmpty()) {
+            return response()->json(['message' => 'No schedules found for the given faculty in the active semester and academic year'], 404);
+        }
+
+        // Step 5: Update the is_published value in the faculty_schedule_publication table for active schedules
+        DB::table('faculty_schedule_publication')
+            ->whereIn('faculty_schedule_publication_id', $facultySchedules->keys())
+            ->update(['is_published' => $isPublished, 'updated_at' => now()]);
+
+        // Step 6: Update the corresponding is_published value in the schedules table for active schedules
+        DB::table('schedules')
+            ->whereIn('schedule_id', $facultySchedules->values())
+            ->update(['is_published' => $isPublished, 'updated_at' => now()]);
+
+        // Step 7: Return a success response
+        return response()->json([
+            'message' => 'Publication status updated successfully for the faculty',
+            'faculty_id' => $facultyId,
+            'is_published' => $isPublished,
+            'updated_schedule_ids' => $facultySchedules->values()
+        ]);
+    }
+
+
+    public function getActiveSchedulesByCourseAssignment()
+    {
+        // Step 1: Get the active semester and academic year
+        $activeSemester = DB::table('active_semesters')
+            ->where('is_active', 1)
+            ->first();
+
+        if (!$activeSemester) {
+            return response()->json(['message' => 'No active semester found'], 404);
+        }
+
+        $activeAcademicYearId = $activeSemester->academic_year_id;
+        $activeSemesterId = $activeSemester->semester_id;
+
+        // Step 2: Fetch schedule IDs using course_assignment_id through section_courses
+        $activeSchedules = DB::table('schedules')
+            ->select('schedules.schedule_id')
+            ->join('section_courses', 'schedules.section_course_id', '=', 'section_courses.section_course_id')
+            ->join('course_assignments', 'section_courses.course_assignment_id', '=', 'course_assignments.course_assignment_id')
+            ->join('sections_per_program_year', 'section_courses.sections_per_program_year_id', '=', 'sections_per_program_year.sections_per_program_year_id')
+            ->join('semesters', 'course_assignments.semester_id', '=', 'semesters.semester_id')
+            ->where('sections_per_program_year.academic_year_id', $activeAcademicYearId)
+            ->where('semesters.semester', $activeSemesterId)
+            ->get();
+
+        // Step 3: Return the result as a JSON response
+        return response()->json([
+            'message' => 'Active schedules fetched successfully',
+            'active_semester_id' => $activeSemester->active_semester_id,
+            'academic_year_id' => $activeAcademicYearId,
+            'semester_id' => $activeSemesterId,
+            'schedule_ids' => $activeSchedules
+        ]);
+    }
+ 
 }
 

--- a/backend/app/Models/CourseAssignment.php
+++ b/backend/app/Models/CourseAssignment.php
@@ -41,4 +41,9 @@ class CourseAssignment extends Model
     {
         return $this->hasMany(Preference::class, 'course_assignment_id', 'course_assignment_id');
     }
+    public function faculty()
+    {
+        return $this->belongsTo(Faculty::class, 'faculty_id');
+    }
+
 }

--- a/backend/app/Models/SectionsPerProgramYear.php
+++ b/backend/app/Models/SectionsPerProgramYear.php
@@ -36,4 +36,8 @@ class SectionsPerProgramYear extends Model
     {
         return $this->belongsTo(ProgramYearLevelCurricula::class, 'program_year_level_curricula_id');
     }
+    public function yearLevel()
+    {
+        return $this->belongsTo(YearLevel::class, 'year_level');
+    }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -46,12 +46,16 @@ Route::post('/assign-schedule', [SchedulingController::class, 'assignSchedule'])
 Route::get('/get-faculty', [SchedulingController::class, 'getFacultyDetails']);
 Route::get('/get-rooms', [RoomController::class, 'getAllRooms']);
 
+//Scheduling related routes
 Route::post('/publish-all-schedule', [SchedulingController::class, 'togglePublishSchedules']);
 Route::post('/publish-single-schedule', [SchedulingController::class, 'toggleIndividualSchedule']);
+// Get single schedule
+Route::post('/get-schedules', [FacultyController::class, 'getIndividualFacultySchedule']);
 // Scheduling Id count base on active a.y and semester for testing
 Route::get('/course-active-count', [SchedulingController::class, 'getActiveSchedulesByCourseAssignment']);
+
 // Scheduling Reports Routes
-Route::get('/faculty-schedules-report', [ReportsController::class, 'getFacultySchedulesReport']);
+Route::get('/faculty-schedules-report', [ReportsController::class, 'getFacultyScheduleReports']);
 
 
 //Scheduling routes

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -46,6 +46,10 @@ Route::post('/assign-schedule', [SchedulingController::class, 'assignSchedule'])
 Route::get('/get-faculty', [SchedulingController::class, 'getFacultyDetails']);
 Route::get('/get-rooms', [RoomController::class, 'getAllRooms']);
 
+Route::post('/publish-all-schedule', [SchedulingController::class, 'togglePublishSchedules']);
+Route::post('/publish-single-schedule', [SchedulingController::class, 'toggleIndividualSchedule']);
+// Scheduling Id count base on active a.y and semester for testing
+Route::get('/course-active-count', [SchedulingController::class, 'getActiveSchedulesByCourseAssignment']);
 // Scheduling Reports Routes
 Route::get('/faculty-schedules-report', [ReportsController::class, 'getFacultySchedulesReport']);
 

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -49,7 +49,7 @@ Route::get('/get-rooms', [RoomController::class, 'getAllRooms']);
 //Scheduling related routes
 Route::post('/publish-all-schedule', [SchedulingController::class, 'togglePublishSchedules']);
 Route::post('/publish-single-schedule', [SchedulingController::class, 'toggleIndividualSchedule']);
-// Get single schedule
+// Get single schedule for faculty viewing schedule
 Route::post('/get-schedules', [FacultyController::class, 'getIndividualFacultySchedule']);
 // Scheduling Id count base on active a.y and semester for testing
 Route::get('/course-active-count', [SchedulingController::class, 'getActiveSchedulesByCourseAssignment']);


### PR DESCRIPTION
This pull request introduces significant enhancements to the `FacultyController` and `ReportsController` to support new functionalities related to faculty schedules. The most important changes include the addition of a new method to retrieve individual faculty schedules, the inclusion of database queries to fetch and organize schedule data, and updates to the reports generation process.

DOWNLOAD THIS AND TEST BY YOUR SELF: 
[PUBLISHING.txt](https://github.com/user-attachments/files/17326915/PUBLISHING.txt)


### Enhancements to FacultyController:

* **New Method for Individual Faculty Schedule:**
  - Added `getIndividualFacultySchedule` method to fetch and return the schedule for a specific faculty member, including validation and detailed database queries. (`backend/app/Http/Controllers/FacultyController.php`)
  - Introduced helper methods like `getFacultySchedules`, `findOrCreateProgram`, `findOrCreateYearLevel`, `findOrCreateSemester`, and `findOrCreateSection` to organize and structure schedule data. (`backend/app/Http/Controllers/FacultyController.php`)

* **Additional Imports:**
  - Added `DB` and `ActiveSemester` model imports to support the new method. (`backend/app/Http/Controllers/FacultyController.php`)

### Updates to ReportsController:

* **Method Renaming and Enhancement:**
  - Renamed `getFacultySchedulesReport` to `getFacultyScheduleReports` and updated it to fetch faculty schedules more efficiently, including faculty without schedules. (`backend/app/Http/Controllers/ReportsController.php`)
  - Added logic to structure the response with detailed schedule data for each faculty member. (`backend/app/Http/Controllers/ReportsController.php`)

These changes improve the functionality and data retrieval processes for faculty schedules, making the application more robust and user-friendly.