### PR TITLE
Scheduling Reports

### DIFF
--- a/backend/app/Http/Controllers/ReportsController.php
+++ b/backend/app/Http/Controllers/ReportsController.php
@@ -382,8 +382,8 @@ class ReportsController extends Controller
                 ];
             }
 
-            // If there's a schedule, add it to the schedules array
-            if ($schedule->schedule_id) {
+            // Check if the schedule has at least one non-null value among the specified fields
+            if ($this->isScheduleValid($schedule)) {
                 $programs[$schedule->program_id]['year_levels'][$schedule->year_level]['sections'][$schedule->section_name]['schedules'][] = [
                     'schedule_id' => $schedule->schedule_id,
                     'day' => $schedule->day,
@@ -405,7 +405,7 @@ class ReportsController extends Controller
             }
         }
 
-        // Step 5: Convert year_levels and sections from associative arrays to indexed arrays
+        // Convert year_levels and sections from associative arrays to indexed arrays
         foreach ($programs as &$program) {
             $program['year_levels'] = array_values($program['year_levels']);
             foreach ($program['year_levels'] as &$yearLevel) {
@@ -413,7 +413,7 @@ class ReportsController extends Controller
             }
         }
 
-        // Step 6: Structure the response
+        // Step 5: Structure the response
         return response()->json([
             'programs_schedule_reports' => [
                 'academic_year_id' => $activeSemester->academic_year_id,
@@ -424,5 +424,17 @@ class ReportsController extends Controller
                 'programs' => array_values($programs)
             ]
         ]);
+    }
+
+    private function isScheduleValid($schedule)
+    {
+        return !(
+            is_null($schedule->day) &&
+            is_null($schedule->start_time) &&
+            is_null($schedule->end_time) &&
+            is_null($schedule->faculty_name) &&
+            is_null($schedule->faculty_code) &&
+            is_null($schedule->room_code)
+        );
     }
 }

--- a/backend/app/Http/Controllers/ReportsController.php
+++ b/backend/app/Http/Controllers/ReportsController.php
@@ -29,40 +29,49 @@ class ReportsController extends Controller
             return response()->json(['message' => 'No active semester found.'], 404);
         }
 
-        // Step 2: Get all faculty schedules with course and program details for the active semester
+        // Step 2: Prepare a subquery to get schedules for the current semester and academic year
+        $schedulesSub = DB::table('schedules')
+            ->join('section_courses', 'schedules.section_course_id', '=', 'section_courses.section_course_id')
+            ->join('course_assignments', 'course_assignments.course_assignment_id', '=', 'section_courses.course_assignment_id')
+            ->join('semesters as ca_semesters', 'ca_semesters.semester_id', '=', 'course_assignments.semester_id')
+            ->join('sections_per_program_year', 'sections_per_program_year.sections_per_program_year_id', '=', 'section_courses.sections_per_program_year_id')
+            ->where('ca_semesters.semester', '=', $activeSemester->semester)
+            ->where('sections_per_program_year.academic_year_id', '=', $activeSemester->academic_year_id)
+            ->select(
+                'schedules.schedule_id',
+                'schedules.faculty_id',
+                'schedules.day',
+                'schedules.start_time',
+                'schedules.end_time',
+                'schedules.room_id',
+                'schedules.section_course_id'
+            );
+
+        // Step 3: Join faculties with current schedules
         $facultySchedules = DB::table('faculty')
             ->join('users', 'faculty.user_id', '=', 'users.id')
-            ->leftJoin('schedules', 'schedules.faculty_id', '=', 'faculty.id')
-            ->leftJoin('section_courses', 'section_courses.section_course_id', '=', 'schedules.section_course_id')
-            ->leftJoin('sections_per_program_year', function ($join) use ($activeSemester) {
-                $join->on('sections_per_program_year.sections_per_program_year_id', '=', 'section_courses.sections_per_program_year_id')
-                     ->where('sections_per_program_year.academic_year_id', '=', $activeSemester->academic_year_id);
+            ->leftJoinSub($schedulesSub, 'current_schedules', function ($join) {
+                $join->on('current_schedules.faculty_id', '=', 'faculty.id');
             })
+            ->leftJoin('section_courses', 'current_schedules.section_course_id', '=', 'section_courses.section_course_id')
+            ->leftJoin('sections_per_program_year', 'sections_per_program_year.sections_per_program_year_id', '=', 'section_courses.sections_per_program_year_id')
             ->leftJoin('programs', 'programs.program_id', '=', 'sections_per_program_year.program_id')
-            ->leftJoin('course_assignments', function ($join) use ($activeSemester) {
-                $join->on('course_assignments.course_assignment_id', '=', 'section_courses.course_assignment_id')
-                     ->join('semesters', 'semesters.semester_id', '=', 'course_assignments.semester_id')
-                     ->where('semesters.semester', '=', $activeSemester->semester);
-            })
+            ->leftJoin('course_assignments', 'course_assignments.course_assignment_id', '=', 'section_courses.course_assignment_id')
             ->leftJoin('courses', 'courses.course_id', '=', 'course_assignments.course_id')
-            ->leftJoin('rooms', 'rooms.room_id', '=', 'schedules.room_id')
+            ->leftJoin('rooms', 'rooms.room_id', '=', 'current_schedules.room_id')
             ->leftJoin('faculty_schedule_publication', function ($join) {
-                $join->on('faculty_schedule_publication.schedule_id', '=', 'schedules.schedule_id')
+                $join->on('faculty_schedule_publication.schedule_id', '=', 'current_schedules.schedule_id')
                      ->on('faculty_schedule_publication.faculty_id', '=', 'faculty.id');
-            })
-            ->where(function ($query) use ($activeSemester) {
-                $query->whereNull('schedules.schedule_id')
-                      ->orWhere('sections_per_program_year.academic_year_id', '=', $activeSemester->academic_year_id);
             })
             ->select(
                 'faculty.id as faculty_id',
                 'users.name as faculty_name',
                 'users.code as faculty_code',
                 'faculty.faculty_type',
-                'schedules.schedule_id',
-                'schedules.day',
-                'schedules.start_time',
-                'schedules.end_time',
+                'current_schedules.schedule_id',
+                'current_schedules.day',
+                'current_schedules.start_time',
+                'current_schedules.end_time',
                 'rooms.room_code',
                 'course_assignments.course_assignment_id',
                 'courses.course_title',
@@ -75,11 +84,11 @@ class ReportsController extends Controller
                 'programs.program_title',
                 'sections_per_program_year.year_level',
                 'sections_per_program_year.section_name',
-                DB::raw('IFNULL(faculty_schedule_publication.is_published, 0) as is_published') 
+                DB::raw('IFNULL(faculty_schedule_publication.is_published, 0) as is_published')
             )
             ->get();
 
-        // Step 3: Group the data by faculty and structure schedules
+        // Step 4: Group the data by faculty and structure schedules
         $faculties = [];
 
         foreach ($facultySchedules as $schedule) {
@@ -95,7 +104,7 @@ class ReportsController extends Controller
                 ];
             }
 
-            if ($schedule->course_assignment_id) {
+            if ($schedule->schedule_id) {
                 $faculties[$schedule->faculty_id]['assigned_units'] += $schedule->units;
                 $faculties[$schedule->faculty_id]['is_published'] = $schedule->is_published;
                 $faculties[$schedule->faculty_id]['schedules'][] = [
@@ -121,7 +130,7 @@ class ReportsController extends Controller
             }
         }
 
-        // Step 4: Structure the response
+        // Step 5: Structure the response
         return response()->json([
             'faculty_schedule_reports' => [
                 'academic_year_id' => $activeSemester->academic_year_id,
@@ -130,6 +139,136 @@ class ReportsController extends Controller
                 'active_semester_id' => $activeSemester->active_semester_id,
                 'semester' => $activeSemester->semester,
                 'faculties' => array_values($faculties)
+            ]
+        ]);
+    }
+
+    public function getRoomSchedulesReport()
+    {
+        // Step 1: Retrieve the current active semester with academic year details
+        $activeSemester = DB::table('active_semesters')
+            ->join('academic_years', 'active_semesters.academic_year_id', '=', 'academic_years.academic_year_id')
+            ->join('semesters', 'active_semesters.semester_id', '=', 'semesters.semester_id')
+            ->where('active_semesters.is_active', 1)
+            ->select(
+                'active_semesters.active_semester_id',
+                'active_semesters.semester_id',
+                'academic_years.academic_year_id',
+                'academic_years.year_start',
+                'academic_years.year_end',
+                'semesters.semester'
+            )
+            ->first();
+
+        if (!$activeSemester) {
+            return response()->json(['message' => 'No active semester found.'], 404);
+        }
+
+        // Step 2: Prepare a subquery to get schedules for the current semester and academic year
+        $schedulesSub = DB::table('schedules')
+            ->join('section_courses', 'schedules.section_course_id', '=', 'section_courses.section_course_id')
+            ->join('course_assignments', 'course_assignments.course_assignment_id', '=', 'section_courses.course_assignment_id')
+            ->join('semesters as ca_semesters', 'ca_semesters.semester_id', '=', 'course_assignments.semester_id')
+            ->join('sections_per_program_year', 'sections_per_program_year.sections_per_program_year_id', '=', 'section_courses.sections_per_program_year_id')
+            ->where('ca_semesters.semester', '=', $activeSemester->semester)
+            ->where('sections_per_program_year.academic_year_id', '=', $activeSemester->academic_year_id)
+            ->select(
+                'schedules.schedule_id',
+                'schedules.room_id',
+                'schedules.day',
+                'schedules.start_time',
+                'schedules.end_time',
+                'schedules.faculty_id',
+                'schedules.section_course_id'
+            );
+
+        // Step 3: Join rooms with current schedules
+        $roomSchedules = DB::table('rooms')
+            ->leftJoinSub($schedulesSub, 'current_schedules', function ($join) {
+                $join->on('current_schedules.room_id', '=', 'rooms.room_id');
+            })
+            ->leftJoin('faculty', 'current_schedules.faculty_id', '=', 'faculty.id')
+            ->leftJoin('users', 'faculty.user_id', '=', 'users.id')
+            ->leftJoin('section_courses', 'current_schedules.section_course_id', '=', 'section_courses.section_course_id')
+            ->leftJoin('sections_per_program_year', 'sections_per_program_year.sections_per_program_year_id', '=', 'section_courses.sections_per_program_year_id')
+            ->leftJoin('programs', 'programs.program_id', '=', 'sections_per_program_year.program_id')
+            ->leftJoin('course_assignments', 'course_assignments.course_assignment_id', '=', 'section_courses.course_assignment_id')
+            ->leftJoin('courses', 'courses.course_id', '=', 'course_assignments.course_id')
+            ->select(
+                'rooms.room_id',
+                'rooms.room_code',
+                'rooms.location',
+                'rooms.floor_level',
+                'rooms.capacity',
+                'current_schedules.schedule_id',
+                'current_schedules.day',
+                'current_schedules.start_time',
+                'current_schedules.end_time',
+                'users.name as faculty_name',
+                'users.code as faculty_code',
+                'programs.program_code',
+                'programs.program_title',
+                'sections_per_program_year.year_level',
+                'sections_per_program_year.section_name',
+                'course_assignments.course_assignment_id',
+                'courses.course_title',
+                'courses.course_code',
+                'courses.lec_hours as lec',
+                'courses.lab_hours as lab',
+                'courses.units',
+                'courses.tuition_hours'
+            )
+            ->get();
+
+        // Step 4: Group the data by room and structure schedules
+        $rooms = [];
+
+        foreach ($roomSchedules as $schedule) {
+            if (!isset($rooms[$schedule->room_id])) {
+                $rooms[$schedule->room_id] = [
+                    'room_id' => $schedule->room_id,
+                    'room_code' => $schedule->room_code,
+                    'location' => $schedule->location,
+                    'floor_level' => $schedule->floor_level,
+                    'capacity' => $schedule->capacity,
+                    'schedules' => []
+                ];
+            }
+
+            if ($schedule->schedule_id) {
+                $rooms[$schedule->room_id]['schedules'][] = [
+                    'schedule_id' => $schedule->schedule_id,
+                    'day' => $schedule->day,
+                    'start_time' => $schedule->start_time,
+                    'end_time' => $schedule->end_time,
+                    'faculty_name' => $schedule->faculty_name,
+                    'faculty_code' => $schedule->faculty_code,
+                    'program_code' => $schedule->program_code,
+                    'program_title' => $schedule->program_title,
+                    'year_level' => $schedule->year_level,
+                    'section_name' => $schedule->section_name,
+                    'course_details' => [
+                        'course_assignment_id' => $schedule->course_assignment_id,
+                        'course_title' => $schedule->course_title,
+                        'course_code' => $schedule->course_code,
+                        'lec' => $schedule->lec,
+                        'lab' => $schedule->lab,
+                        'units' => $schedule->units,
+                        'tuition_hours' => $schedule->tuition_hours
+                    ]
+                ];
+            }
+        }
+
+        // Step 5: Structure the response
+        return response()->json([
+            'room_schedule_reports' => [
+                'academic_year_id' => $activeSemester->academic_year_id,
+                'year_start' => $activeSemester->year_start,
+                'year_end' => $activeSemester->year_end,
+                'active_semester_id' => $activeSemester->active_semester_id,
+                'semester' => $activeSemester->semester,
+                'rooms' => array_values($rooms)
             ]
         ]);
     }

--- a/backend/app/Http/Controllers/ReportsController.php
+++ b/backend/app/Http/Controllers/ReportsController.php
@@ -13,21 +13,23 @@ class ReportsController extends Controller
         // Step 1: Retrieve the current active semester with academic year details
         $activeSemester = DB::table('active_semesters')
             ->join('academic_years', 'active_semesters.academic_year_id', '=', 'academic_years.academic_year_id')
+            ->join('semesters', 'active_semesters.semester_id', '=', 'semesters.semester_id')
             ->where('active_semesters.is_active', 1)
             ->select(
                 'active_semesters.active_semester_id',
                 'active_semesters.semester_id',
                 'academic_years.academic_year_id',
                 'academic_years.year_start',
-                'academic_years.year_end'
+                'academic_years.year_end',
+                'semesters.semester'
             )
             ->first();
-    
+
         if (!$activeSemester) {
             return response()->json(['message' => 'No active semester found.'], 404);
         }
-    
-        // Step 2: Get all faculty schedules with course details, including faculty without schedules
+
+        // Step 2: Get all faculty schedules with course and program details for the active semester
         $facultySchedules = DB::table('faculty')
             ->join('users', 'faculty.user_id', '=', 'users.id')
             ->leftJoin('schedules', 'schedules.faculty_id', '=', 'faculty.id')
@@ -36,12 +38,22 @@ class ReportsController extends Controller
                 $join->on('sections_per_program_year.sections_per_program_year_id', '=', 'section_courses.sections_per_program_year_id')
                      ->where('sections_per_program_year.academic_year_id', '=', $activeSemester->academic_year_id);
             })
+            ->leftJoin('programs', 'programs.program_id', '=', 'sections_per_program_year.program_id')
             ->leftJoin('course_assignments', function ($join) use ($activeSemester) {
                 $join->on('course_assignments.course_assignment_id', '=', 'section_courses.course_assignment_id')
-                     ->where('course_assignments.semester_id', '=', $activeSemester->semester_id);
+                     ->join('semesters', 'semesters.semester_id', '=', 'course_assignments.semester_id')
+                     ->where('semesters.semester', '=', $activeSemester->semester);
             })
             ->leftJoin('courses', 'courses.course_id', '=', 'course_assignments.course_id')
             ->leftJoin('rooms', 'rooms.room_id', '=', 'schedules.room_id')
+            ->leftJoin('faculty_schedule_publication', function ($join) {
+                $join->on('faculty_schedule_publication.schedule_id', '=', 'schedules.schedule_id')
+                     ->on('faculty_schedule_publication.faculty_id', '=', 'faculty.id');
+            })
+            ->where(function ($query) use ($activeSemester) {
+                $query->whereNull('schedules.schedule_id')
+                      ->orWhere('sections_per_program_year.academic_year_id', '=', $activeSemester->academic_year_id);
+            })
             ->select(
                 'faculty.id as faculty_id',
                 'users.name as faculty_name',
@@ -59,13 +71,17 @@ class ReportsController extends Controller
                 'courses.lab_hours',
                 'courses.units',
                 'courses.tuition_hours',
-                'schedules.is_published'
+                'programs.program_code',
+                'programs.program_title',
+                'sections_per_program_year.year_level',
+                'sections_per_program_year.section_name',
+                DB::raw('IFNULL(faculty_schedule_publication.is_published, 0) as is_published') 
             )
             ->get();
-    
+
         // Step 3: Group the data by faculty and structure schedules
         $faculties = [];
-    
+
         foreach ($facultySchedules as $schedule) {
             if (!isset($faculties[$schedule->faculty_id])) {
                 $faculties[$schedule->faculty_id] = [
@@ -74,20 +90,24 @@ class ReportsController extends Controller
                     'faculty_code' => $schedule->faculty_code,
                     'faculty_type' => $schedule->faculty_type,
                     'assigned_units' => 0,
-                    'is_published' => $schedule->is_published,
+                    'is_published' => 0,
                     'schedules' => []
                 ];
             }
-    
+
             if ($schedule->course_assignment_id) {
                 $faculties[$schedule->faculty_id]['assigned_units'] += $schedule->units;
-    
+                $faculties[$schedule->faculty_id]['is_published'] = $schedule->is_published;
                 $faculties[$schedule->faculty_id]['schedules'][] = [
                     'schedule_id' => $schedule->schedule_id,
                     'day' => $schedule->day,
                     'start_time' => $schedule->start_time,
                     'end_time' => $schedule->end_time,
                     'room_code' => $schedule->room_code,
+                    'program_code' => $schedule->program_code,
+                    'program_title' => $schedule->program_title,
+                    'year_level' => $schedule->year_level,
+                    'section_name' => $schedule->section_name,
                     'course_details' => [
                         'course_assignment_id' => $schedule->course_assignment_id,
                         'course_title' => $schedule->course_title,
@@ -100,7 +120,7 @@ class ReportsController extends Controller
                 ];
             }
         }
-    
+
         // Step 4: Structure the response
         return response()->json([
             'faculty_schedule_reports' => [
@@ -108,7 +128,7 @@ class ReportsController extends Controller
                 'year_start' => $activeSemester->year_start,
                 'year_end' => $activeSemester->year_end,
                 'active_semester_id' => $activeSemester->active_semester_id,
-                'semester' => $activeSemester->semester_id,
+                'semester' => $activeSemester->semester,
                 'faculties' => array_values($faculties)
             ]
         ]);

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -48,6 +48,7 @@ Route::get('/get-rooms', [RoomController::class, 'getAllRooms']);
 
 // Scheduling Reports Routes
 Route::get('/faculty-schedules-report', [ReportsController::class, 'getFacultySchedulesReport']);
+Route::get('/room-schedules-report', [ReportsController::class, 'getRoomSchedulesReport']);
 
 
 //Scheduling routes

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -49,7 +49,7 @@ Route::get('/get-rooms', [RoomController::class, 'getAllRooms']);
 // Scheduling Reports Routes
 Route::get('/faculty-schedules-report', [ReportsController::class, 'getFacultySchedulesReport']);
 Route::get('/room-schedules-report', [ReportsController::class, 'getRoomSchedulesReport']);
-
+Route::get('/program-schedules-report', [ReportsController::class, 'getProgramSchedulesReport']);
 
 //Scheduling routes
 Route::post('/submit-preferences', [PreferenceController::class, 'submitPreferences']);

--- a/frontend/src/app/core/animations/animations.ts
+++ b/frontend/src/app/core/animations/animations.ts
@@ -1,4 +1,12 @@
-import { trigger, transition, style, animate, state, query, stagger } from '@angular/animations';
+import {
+  trigger,
+  transition,
+  style,
+  animate,
+  state,
+  query,
+  stagger,
+} from '@angular/animations';
 
 // Anmation 1: Simple Fade - used in route transitions
 export const fadeAnimation = trigger('fadeAnimation', [
@@ -68,9 +76,25 @@ export const cardEntranceSide = trigger('cardEntranceSide', [
 export const pageFloatUpAnimation = trigger('pageFloatUpAnimation', [
   transition(':enter', [
     style({ opacity: 0, transform: 'translateY(20px)' }),
-    animate('400ms ease-out', style({ opacity: 1, transform: 'translateY(0)' }))
+    animate(
+      '400ms ease-out',
+      style({ opacity: 1, transform: 'translateY(0)' })
+    ),
   ]),
   transition(':leave', [
-    animate('300ms ease-in', style({ opacity: 0, transform: 'translateY(20px)' }))
-  ])
-]); 
+    animate(
+      '300ms ease-in',
+      style({ opacity: 0, transform: 'translateY(20px)' })
+    ),
+  ]),
+]);
+
+export const rowAdditionAnimation = trigger('rowAdditionAnimation', [
+  transition(':enter', [
+    style({ opacity: 0, transform: 'translateX(-50px)' }),
+    animate(
+      '500ms cubic-bezier(0.25, 1, 0.5, 1)',
+      style({ opacity: 1, transform: 'translateX(0)' })
+    ),
+  ]),
+]);

--- a/frontend/src/app/core/components/admin/reports/report-faculty/report-faculty.component.ts
+++ b/frontend/src/app/core/components/admin/reports/report-faculty/report-faculty.component.ts
@@ -106,8 +106,9 @@ export class ReportFacultyComponent
             facultyUnits: faculty.assigned_units,
             isEnabled: faculty.is_published === 1,
             facultyId: faculty.faculty_id,
+            schedules: faculty.schedules,
             academicYear: `${response.faculty_schedule_reports.year_start}-${response.faculty_schedule_reports.year_end}`,
-            semester: this.getSemesterDisplay(response.faculty_schedule_reports.semester), // Use the helper function here
+            semester: this.getSemesterDisplay(response.faculty_schedule_reports.semester),
           })
         );
 
@@ -167,7 +168,7 @@ export class ReportFacultyComponent
       data: {
         exportType: 'single',
         entity: 'faculty',
-        entityData: element,
+        entityData: element.schedules,
         customTitle: `${element.facultyName}`,
         academicYear: element.academicYear,
         semester: element.semester,

--- a/frontend/src/app/core/components/admin/reports/report-programs/report-programs.component.html
+++ b/frontend/src/app/core/components/admin/reports/report-programs/report-programs.component.html
@@ -1,4 +1,10 @@
 <div class="report-container">
+  <!--Display while loading-->
+  @if (isLoading) {
+  <div class="loading-wrapper">
+    <app-loading></app-loading>
+  </div>
+  } @else {
   <!-- Programs Report Header-->
   <div class="report-header-container" [@fadeAnimation]>
     <app-table-header
@@ -21,13 +27,7 @@
             #
           </th>
           <td mat-cell *matCellDef="let element; let i = index" class="index">
-            <span>
-              {{
-                i +
-                  1 +
-                  (paginator?.pageIndex || 0) * (paginator?.pageSize || 10)
-              }}
-            </span>
+            <span>{{ getRowIndex(i) }}</span>
           </td>
         </ng-container>
 
@@ -37,7 +37,7 @@
             Program Code
           </th>
           <td mat-cell *matCellDef="let element" class="custom-cell">
-            {{ element.programCode }}
+            {{ element.program_code }}
           </td>
         </ng-container>
 
@@ -47,19 +47,27 @@
             Program Name
           </th>
           <td mat-cell *matCellDef="let element" class="custom-cell">
-            {{ element.programName }}
+            {{ element.program_title }}
           </td>
         </ng-container>
 
         <!-- Year Level Column -->
         <ng-container matColumnDef="yearLevel">
           <th mat-header-cell *matHeaderCellDef class="custom-header">
-            Year Level
+            Year Levels
           </th>
           <td mat-cell *matCellDef="let element" class="custom-cell">
-            <button mat-button class="prim-button" (click)="onOpenDialog(element, 'yearLevel')">
+            <button
+              mat-button
+              class="prim-button"
+              (click)="onOpenDialog(element, 'yearLevel')"
+            >
               <mat-icon>school</mat-icon>
-              {{ element.yearLevel || "All Year Levels" }}
+              {{
+                element.year_levels_selected === "All"
+                  ? "All Year Levels"
+                  : "Year Level " + element.year_levels_selected
+              }}
             </button>
           </td>
         </ng-container>
@@ -67,12 +75,20 @@
         <!-- Section Column -->
         <ng-container matColumnDef="section">
           <th mat-header-cell *matHeaderCellDef class="custom-header">
-            Section
+            Sections
           </th>
           <td mat-cell *matCellDef="let element" class="custom-cell">
-            <button mat-button class="prim-button" (click)="onOpenDialog(element, 'section')">
+            <button
+              mat-button
+              class="prim-button"
+              (click)="onOpenDialog(element, 'section')"
+            >
               <mat-icon>view_list</mat-icon>
-              {{ 'Section ' + element.section || "All Sections" }}
+              {{
+                element.section_selected === "All"
+                  ? "All Sections"
+                  : "Section " + element.section_selected
+              }}
             </button>
           </td>
         </ng-container>
@@ -129,4 +145,5 @@
       </mat-paginator>
     </div>
   </div>
+  }
 </div>

--- a/frontend/src/app/core/components/admin/reports/report-programs/report-programs.component.ts
+++ b/frontend/src/app/core/components/admin/reports/report-programs/report-programs.component.ts
@@ -1,25 +1,62 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { MatTableModule } from '@angular/material/table';
-import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatTableModule, MatTableDataSource } from '@angular/material/table';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar'; 
 
-import {
-  InputField,
-  TableHeaderComponent,
-} from '../../../../../shared/table-header/table-header.component';
-import {
-  TableDialogComponent,
-  DialogConfig,
-  DialogFieldConfig,
-} from '../../../../../shared/table-dialog/table-dialog.component';
+import { TableHeaderComponent, InputField } from '../../../../../shared/table-header/table-header.component';
+import { TableDialogComponent, DialogConfig, DialogFieldConfig } from '../../../../../shared/table-dialog/table-dialog.component';
+import { LoadingComponent } from '../../../../../shared/loading/loading.component';
+
+import { ReportsService } from '../../../../services/admin/reports/reports.service';
 
 import { fadeAnimation } from '../../../../animations/animations';
+
+interface CourseDetails {
+  course_assignment_id: number;
+  course_title: string;
+  course_code: string;
+  lec: number;
+  lab: number;
+  units: number;
+  tuition_hours: number;
+}
+
+interface Schedule {
+  schedule_id: number;
+  day: string;
+  start_time: string;
+  end_time: string;
+  faculty_name: string;
+  faculty_code: string;
+  room_code: string;
+  course_details: CourseDetails;
+}
+
+interface Section {
+  section_name: string;
+  schedules: Schedule[];
+}
+
+interface YearLevel {
+  year_level: number;
+  sections: Section[];
+}
+
+interface Program {
+  program_id: number;
+  program_code: string;
+  program_title: string;
+  year_levels: YearLevel[];
+  year_levels_selected?: string;
+  section_selected?: string;
+}
 
 @Component({
   selector: 'app-report-programs',
@@ -34,12 +71,13 @@ import { fadeAnimation } from '../../../../animations/animations';
     MatTooltipModule,
     TableHeaderComponent,
     TableDialogComponent,
+    LoadingComponent,
   ],
   templateUrl: './report-programs.component.html',
-  styleUrl: './report-programs.component.scss',
+  styleUrls: ['./report-programs.component.scss'],
   animations: [fadeAnimation],
 })
-export class ReportProgramsComponent {
+export class ReportProgramsComponent implements OnInit {
   inputFields: InputField[] = [
     {
       type: 'text',
@@ -47,6 +85,7 @@ export class ReportProgramsComponent {
       key: 'search',
     },
   ];
+
   displayedColumns: string[] = [
     'index',
     'programCode',
@@ -55,108 +94,153 @@ export class ReportProgramsComponent {
     'section',
     'action',
   ];
-  dataSource = [
-    {
-      programName: 'Bachelor of Science in Information Technology',
-      programCode: 'BSIT-TG',
-      yearLevel: '1st Year',
-      section: '1',
-    },
-    {
-      programName: 'Bachelor of Science in Mechanical Engineering',
-      programCode: 'BSME-TG',
-      yearLevel: '1st Year',
-      section: '1',
-    },
-    {
-      programName: 'Bachelor of Science in Computer Science',
-      programCode: 'BSCS-TG',
-      yearLevel: '2nd Year',
-      section: '1',
-    },
-    {
-      programName: 'Bachelor of Science in Electrical Engineering',
-      programCode: 'BSEE-TG',
-      yearLevel: '2nd Year',
-      section: '1',
-    },
-    {
-      programName: 'Bachelor of Arts in Business Administration',
-      programCode: 'BBA-TG',
-      yearLevel: '1st Year',
-      section: '1',
-    },
-    {
-      programName: 'Bachelor of Science in Civil Engineering',
-      programCode: 'BSCE-TG',
-      yearLevel: '3rd Year',
-      section: '1',
-    },
-    {
-      programName: 'Bachelor of Science in Nursing',
-      programCode: 'BSN-TG',
-      yearLevel: '1st Year',
-      section: '1',
-    },
-    {
-      programName: 'Bachelor of Science in Psychology',
-      programCode: 'BSP-TG',
-      yearLevel: '2nd Year',
-      section: '1',
-    },
-    {
-      programName: 'Bachelor of Science in Hospitality Management',
-      programCode: 'BSHM-TG',
-      yearLevel: '1st Year',
-      section: '1',
-    },
-    {
-      programName: 'Bachelor of Fine Arts',
-      programCode: 'BFA-TG',
-      yearLevel: '4th Year',
-      section: '1',
-    },
-    {
-      programName: 'Bachelor of Science in Marketing',
-      programCode: 'BSM-TG',
-      yearLevel: '2nd Year',
-      section: '1',
-    },
-    {
-      programName: 'Bachelor of Science in Accounting',
-      programCode: 'BSAc-TG',
-      yearLevel: '4th Year',
-      section: '1',
-    },
-  ];
 
-  filteredData = this.dataSource;
-  paginator: any;
+  dataSource = new MatTableDataSource<Program>();
+  filteredData: Program[] = [];
+  isLoading = true;
 
-  constructor(private dialog: MatDialog) {}
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
 
-  onOpenDialog(element: any, field: string) {
+  constructor(
+    private reportsService: ReportsService,
+    private dialog: MatDialog,
+    private snackBar: MatSnackBar
+  ) {}
+
+  ngOnInit(): void {
+    this.fetchProgramsData();
+  }
+
+  ngAfterViewInit() {
+    this.dataSource.paginator = this.paginator;
+  }
+
+  fetchProgramsData(): void {
+    this.isLoading = true;
+    this.reportsService.getProgramSchedulesReport().subscribe({
+      next: (response) => {
+        const programData: Program[] =
+          response.programs_schedule_reports.programs.map((program: any) => ({
+            program_id: program.program_id,
+            program_code: program.program_code,
+            program_title: program.program_title,
+            year_levels: program.year_levels.map((yl: any) => ({
+              year_level: yl.year_level,
+              sections: yl.sections.map((sec: any) => ({
+                section_name: sec.section_name,
+                schedules: sec.schedules,
+              })),
+            })),
+            year_levels_selected: 'All',
+            section_selected: 'All',
+          }));
+
+        this.isLoading = false;
+        this.dataSource.data = programData;
+        this.filteredData = [...programData];
+        this.dataSource.paginator = this.paginator;
+      },
+      error: (error) => {
+        this.isLoading = false;
+        console.error('Error fetching programs data:', error);
+        this.snackBar.open(
+          'Failed to load programs data. Please try again later.',
+          'Close',
+          {
+            duration: 5000,
+          }
+        );
+      },
+    });
+  }
+
+  getRowIndex(index: number): number {
+    if (this.paginator) {
+      return index + 1 + this.paginator.pageIndex * this.paginator.pageSize;
+    }
+    return index + 1;
+  }
+
+  onInputChange(changes: { [key: string]: any }) {
+    const searchQuery = changes['search']
+      ? changes['search'].trim().toLowerCase()
+      : '';
+
+    if (searchQuery === '') {
+      this.dataSource.data = this.filteredData;
+    } else {
+      this.dataSource.data = this.filteredData.filter(
+        (program) =>
+          program.program_code.toLowerCase().includes(searchQuery) ||
+          program.program_title.toLowerCase().includes(searchQuery)
+      );
+    }
+  }
+
+  onExportAll() {
+    console.log('Export All clicked');
+  }
+
+  onView(element: Program) {
+    console.log('View Schedule clicked');
+  }
+
+  onExportSingle(element: Program) {
+    console.log('Export Single clicked for:', element);
+  }
+
+  onOpenDialog(program: Program, field: 'yearLevel' | 'section') {
     let dialogFields: DialogFieldConfig[] = [];
     let title = '';
+    let options: string[] = [];
 
     if (field === 'yearLevel') {
+      // Extract unique year levels from the program
+      const uniqueYearLevels = program.year_levels.map((yl) => yl.year_level);
+      options = ['All', ...uniqueYearLevels.map(String)];
       dialogFields = [
         {
           label: 'Year Level',
           formControlName: 'yearLevel',
           type: 'select',
-          options: ['All', '1', '2', '3', '4'],
+          options: options,
           required: true,
         },
       ];
       title = 'Select Year Level';
     } else if (field === 'section') {
+      if (program.year_levels_selected === 'All') {
+        // Get all unique sections across all year levels
+        const uniqueSections = Array.from(
+          new Set(
+            program.year_levels.flatMap((yl) =>
+              yl.sections.map((sec) => sec.section_name)
+            )
+          )
+        );
+        options = ['All', ...uniqueSections];
+      } else {
+        // Find the selected year level
+        const selectedYearLevel = program.year_levels.find(
+          (yl) => yl.year_level.toString() === program.year_levels_selected
+        );
+        if (selectedYearLevel) {
+          const sections = selectedYearLevel.sections.map(
+            (sec) => sec.section_name
+          );
+          options = ['All', ...sections];
+        } else {
+          // Fallback in case no matching year level is found
+          options = ['All'];
+        }
+      }
+
       dialogFields = [
         {
           label: 'Section',
           formControlName: 'section',
           type: 'select',
-          options: ['All', '1'],
+          options: options,
           required: true,
         },
       ];
@@ -167,7 +251,12 @@ export class ReportProgramsComponent {
       title,
       fields: dialogFields,
       isEdit: true,
-      initialValue: { [field]: element[field] || 'All' },
+      initialValue: {
+        [field === 'yearLevel' ? 'yearLevel' : 'section']:
+          field === 'yearLevel'
+            ? program.year_levels_selected
+            : program.section_selected,
+      },
     };
 
     const dialogRef = this.dialog.open(TableDialogComponent, {
@@ -176,25 +265,15 @@ export class ReportProgramsComponent {
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
-        element[field] = result[field];
+        if (field === 'yearLevel') {
+          program.year_levels_selected = result.yearLevel;
+          program.section_selected = 'All';
+        } else if (field === 'section') {
+          program.section_selected = result.section;
+        }
+        // Further logic can be implemented based on the selection
       }
     });
-  }
-
-  onExportAll() {
-    console.log('Export All clicked');
-  }
-
-  onInputChange(event: any) {
-    console.log('Input Change:', event);
-  }
-
-  onView(element: any) {
-    console.log('View clicked:', element);
-  }
-
-  onExportSingle(element: any) {
-    console.log('Export Single clicked:', element);
   }
 
   updateDisplayedData() {

--- a/frontend/src/app/core/components/admin/reports/report-programs/report-programs.component.ts
+++ b/frontend/src/app/core/components/admin/reports/report-programs/report-programs.component.ts
@@ -9,8 +9,15 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialog } from '@angular/material/dialog';
 
-import { InputField, TableHeaderComponent } from '../../../../../shared/table-header/table-header.component';
-import { TableDialogComponent, DialogConfig, DialogFieldConfig } from '../../../../../shared/table-dialog/table-dialog.component';
+import {
+  InputField,
+  TableHeaderComponent,
+} from '../../../../../shared/table-header/table-header.component';
+import {
+  TableDialogComponent,
+  DialogConfig,
+  DialogFieldConfig,
+} from '../../../../../shared/table-dialog/table-dialog.component';
 
 import { fadeAnimation } from '../../../../animations/animations';
 
@@ -160,7 +167,7 @@ export class ReportProgramsComponent {
       title,
       fields: dialogFields,
       isEdit: true,
-      initialValue: { [field]: element[field] },
+      initialValue: { [field]: element[field] || 'All' },
     };
 
     const dialogRef = this.dialog.open(TableDialogComponent, {

--- a/frontend/src/app/core/components/admin/reports/report-programs/report-programs.component.ts
+++ b/frontend/src/app/core/components/admin/reports/report-programs/report-programs.component.ts
@@ -250,7 +250,7 @@ export class ReportProgramsComponent implements OnInit {
     const dialogConfig: DialogConfig = {
       title,
       fields: dialogFields,
-      isEdit: true,
+      isEdit: false,
       initialValue: {
         [field === 'yearLevel' ? 'yearLevel' : 'section']:
           field === 'yearLevel'

--- a/frontend/src/app/core/components/admin/reports/report-programs/report-programs.component.ts
+++ b/frontend/src/app/core/components/admin/reports/report-programs/report-programs.component.ts
@@ -1,5 +1,3 @@
-// report-programs.component.ts
-
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 

--- a/frontend/src/app/core/components/admin/reports/report-rooms/report-rooms.component.html
+++ b/frontend/src/app/core/components/admin/reports/report-rooms/report-rooms.component.html
@@ -61,6 +61,16 @@
           </td>
         </ng-container>
 
+        <!-- Capacity Column -->
+        <ng-container matColumnDef="capacity">
+          <th mat-header-cell *matHeaderCellDef class="custom-header">
+            Capacity
+          </th>
+          <td mat-cell *matCellDef="let element" class="custom-cell">
+            {{ element.capacity }}
+          </td>
+        </ng-container>
+
         <!-- Action Column -->
         <ng-container matColumnDef="action">
           <th mat-header-cell *matHeaderCellDef class="custom-header">

--- a/frontend/src/app/core/components/admin/reports/report-rooms/report-rooms.component.html
+++ b/frontend/src/app/core/components/admin/reports/report-rooms/report-rooms.component.html
@@ -1,4 +1,10 @@
 <div class="report-container">
+  <!--Display while loading-->
+  @if (isLoading) {
+  <div class="loading-wrapper">
+    <app-loading></app-loading>
+  </div>
+  } @else {
   <!-- Rooms Report Header-->
   <div class="report-header-container" [@fadeAnimation]>
     <app-table-header
@@ -22,11 +28,7 @@
           </th>
           <td mat-cell *matCellDef="let element; let i = index" class="index">
             <span>
-              {{
-                i +
-                  1 +
-                  (paginator?.pageIndex || 0) * (paginator?.pageSize || 10)
-              }}
+              {{ getRowIndex(i) }}
             </span>
           </td>
         </ng-container>
@@ -53,11 +55,9 @@
 
         <!-- Floor Column -->
         <ng-container matColumnDef="floor">
-          <th mat-header-cell *matHeaderCellDef class="custom-header">
-            Floor
-          </th>
+          <th mat-header-cell *matHeaderCellDef class="custom-header">Floor</th>
           <td mat-cell *matCellDef="let element" class="custom-cell">
-            {{ element.floor }}
+            {{ element.floorLevel }} Floor
           </td>
         </ng-container>
 
@@ -86,6 +86,7 @@
           </td>
         </ng-container>
 
+        <!-- Header and Row Declarations -->
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
         <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
 
@@ -113,4 +114,5 @@
       </mat-paginator>
     </div>
   </div>
+  }
 </div>

--- a/frontend/src/app/core/components/admin/reports/report-rooms/report-rooms.component.ts
+++ b/frontend/src/app/core/components/admin/reports/report-rooms/report-rooms.component.ts
@@ -61,6 +61,7 @@ export class ReportRoomsComponent implements OnInit, AfterViewInit, AfterViewChe
     'roomCode',
     'location',
     'floor',
+    'capacity',
     'action',
   ];
 

--- a/frontend/src/app/core/components/admin/reports/report-rooms/report-rooms.component.ts
+++ b/frontend/src/app/core/components/admin/reports/report-rooms/report-rooms.component.ts
@@ -162,7 +162,7 @@ export class ReportRoomsComponent implements OnInit, AfterViewInit, AfterViewChe
         exportType: 'single',
         entity: 'room',
         entityData: element.schedules,
-        customTitle: `Room ${element.roomCode} Schedule`,
+        customTitle: `Room ${element.roomCode}`,
         academicYear: element.academicYear,
         semester: element.semester,
       },

--- a/frontend/src/app/core/components/admin/reports/report-rooms/report-rooms.component.ts
+++ b/frontend/src/app/core/components/admin/reports/report-rooms/report-rooms.component.ts
@@ -1,35 +1,53 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, ViewChild, AfterViewInit, AfterViewChecked } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 
-import { MatTableModule } from '@angular/material/table';
-import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatTableModule, MatTableDataSource } from '@angular/material/table';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
-import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 
-import { InputField, TableHeaderComponent } from '../../../../../shared/table-header/table-header.component';
+import { TableHeaderComponent, InputField } from '../../../../../shared/table-header/table-header.component';
+import { LoadingComponent } from '../../../../../shared/loading/loading.component';
+import { DialogViewScheduleComponent } from '../../../../../shared/dialog-view-schedule/dialog-view-schedule.component';
+
+import { ReportsService } from '../../../../services/admin/reports/reports.service';
 
 import { fadeAnimation } from '../../../../animations/animations';
+
+interface Room {
+  academicYear: any;
+  semester: any;
+  roomId: number;
+  roomCode: string;
+  location: string;
+  floorLevel: string;
+  capacity: number;
+  schedules: any[];
+}
 
 @Component({
   selector: 'app-report-rooms',
   standalone: true,
   imports: [
     CommonModule,
+    TableHeaderComponent,
+    LoadingComponent,
     MatTableModule,
     MatPaginatorModule,
     MatIconModule,
     MatButtonModule,
-    MatSlideToggleModule,
     MatTooltipModule,
-    TableHeaderComponent,
+    FormsModule,
+    MatDialogModule,
   ],
   templateUrl: './report-rooms.component.html',
-  styleUrl: './report-rooms.component.scss',
+  styleUrls: ['./report-rooms.component.scss'],
   animations: [fadeAnimation],
 })
-export class ReportRoomsComponent {
+export class ReportRoomsComponent implements OnInit, AfterViewInit, AfterViewChecked {
   inputFields: InputField[] = [
     {
       type: 'text',
@@ -37,6 +55,7 @@ export class ReportRoomsComponent {
       key: 'search',
     },
   ];
+
   displayedColumns: string[] = [
     'index',
     'roomCode',
@@ -45,55 +64,123 @@ export class ReportRoomsComponent {
     'action',
   ];
 
-  // Temporary mock data
-  dataSource = [
-    {
-      roomCode: 'A101',
-      location: 'Building A',
-      floor: '1st Floor',
-    },
-    {
-      roomCode: 'A202',
-      location: 'Building A',
-      floor: '2nd Floor',
-    },
-    {
-      roomCode: 'A303',
-      location: 'Building A',
-      floor: '3rd Floor',
-    },
-    {
-      roomCode: 'A404',
-      location: 'Building A',
-      floor: '4th Floor',
-    },
-    {
-      roomCode: 'DOST-LAB',
-      location: 'Building a',
-      floor: '2nd Floor',
-    },
-  ];
+  dataSource = new MatTableDataSource<Room>();
+  filteredData: Room[] = [];
+  isLoading = true;
 
-  filteredData = this.dataSource;
-  paginator: any;
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+
+  constructor(
+    private reportsService: ReportsService,
+    public dialog: MatDialog
+  ) {}
+
+  ngOnInit(): void {
+    this.fetchRoomData();
+  }
+
+  ngAfterViewInit() {
+    this.dataSource.paginator = this.paginator;
+  }
+
+  ngAfterViewChecked() {
+    if (this.dataSource.paginator !== this.paginator) {
+      this.dataSource.paginator = this.paginator;
+    }
+  }
+
+  fetchRoomData(): void {
+    this.isLoading = true;
+    this.reportsService.getRoomSchedulesReport().subscribe({
+      next: (response) => {
+        const rooms = response.room_schedule_reports.rooms.map((room: any) => ({
+          roomId: room.room_id,
+          roomCode: room.room_code,
+          location: room.location,
+          floorLevel: room.floor_level,
+          capacity: room.capacity,
+          schedules: room.schedules,
+          academicYear: `${response.room_schedule_reports.year_start}-${response.room_schedule_reports.year_end}`,
+          semester: this.getSemesterDisplay(response.room_schedule_reports.semester),
+        }));
+
+        this.isLoading = false;
+        this.dataSource.data = rooms;
+        this.filteredData = [...rooms];
+        this.dataSource.paginator = this.paginator;
+      },
+      error: (error) => {
+        this.isLoading = false;
+        console.error('Error fetching room data:', error);
+      },
+    });
+  }
+
+  getSemesterDisplay(semester: number): string {
+    switch (semester) {
+      case 1:
+        return '1st Semester';
+      case 2:
+        return '2nd Semester';
+      case 3:
+        return 'Summer Semester';
+      default:
+        return 'Unknown Semester';
+    }
+  }
+
+  getRowIndex(index: number): number {
+    if (this.paginator) {
+      return index + 1 + this.paginator.pageIndex * this.paginator.pageSize;
+    }
+    return index + 1;
+  }
+
+  onInputChange(changes: { [key: string]: any }) {
+    const searchQuery = changes['search']
+      ? changes['search'].trim().toLowerCase()
+      : '';
+
+    if (searchQuery === '') {
+      this.dataSource.data = this.filteredData;
+    } else {
+      this.dataSource.data = this.filteredData.filter(
+        (room) =>
+          room.roomCode.toLowerCase().includes(searchQuery) ||
+          room.location.toLowerCase().includes(searchQuery) ||
+          room.floorLevel.toLowerCase().includes(searchQuery)
+      );
+    }
+  }
+
+  onView(element: Room) {
+    this.dialog.open(DialogViewScheduleComponent, {
+      maxWidth: '70rem',
+      width: '100%',
+      data: {
+        exportType: 'single',
+        entity: 'room',
+        entityData: element.schedules,
+        customTitle: `Room ${element.roomCode} Schedule`,
+        academicYear: element.academicYear,
+        semester: element.semester,
+      },
+      disableClose: true,
+    });
+  }
 
   onExportAll() {
     console.log('Export All clicked');
+    // Implement export all functionality here
   }
 
-  onInputChange(event: any) {
-    console.log('Input Change:', event);
-  }
-
-  onView(element: any) {
-    console.log('View clicked:', element);
-  }
-
-  onExportSingle(element: any) {
-    console.log('Export Single clicked:', element);
+  onExportSingle(element: Room) {
+    console.log('Export clicked for:', element);
+    // Implement export single functionality here
   }
 
   updateDisplayedData() {
-    console.log('Page changed');
+    console.log('Paginator updated');
+    // Additional paginator-related logic can be added here
   }
 }

--- a/frontend/src/app/core/components/faculty/preferences/preferences.component.html
+++ b/frontend/src/app/core/components/faculty/preferences/preferences.component.html
@@ -86,7 +86,6 @@
             <div
               class="course-card pop"
               matRipple
-              (click)="addCourseToTable(course)"
             >
               <div class="course-info">
                 <span class="course-code">{{ course.course_code }}</span>
@@ -143,7 +142,6 @@
             <div
               class="course-card pop"
               matRipple
-              (click)="addCourseToTable(course)"
             >
               <div class="course-info">
                 <span class="course-code">{{ course.course_code }}</span>

--- a/frontend/src/app/core/components/faculty/preferences/preferences.component.html
+++ b/frontend/src/app/core/components/faculty/preferences/preferences.component.html
@@ -83,7 +83,11 @@
         <div class="courses-scroll-container">
           <div [@cardEntranceAnimation]="filteredSearchResults.length">
             @for (course of filteredSearchResults; track course.course_id) {
-            <div class="course-card" matRipple>
+            <div
+              class="course-card pop"
+              matRipple
+              (click)="addCourseToTable(course)"
+            >
               <div class="course-info">
                 <span class="course-code">{{ course.course_code }}</span>
                 <span class="course-title">{{ course.course_title }}</span>
@@ -109,7 +113,7 @@
           <div [@cardEntranceAnimation]="programs.length">
             @for (program of programs; track trackByProgramId($index, program)){
             <div
-              class="program-card"
+              class="program-card pop"
               (click)="selectProgram(program)"
               matRipple
             >
@@ -136,7 +140,11 @@
           <div [@cardEntranceAnimation]="filteredCourses.length">
             @for (course of filteredCourses; track trackByCourseId($index,
             course)) {
-            <div class="course-card" matRipple>
+            <div
+              class="course-card pop"
+              matRipple
+              (click)="addCourseToTable(course)"
+            >
               <div class="course-info">
                 <span class="course-code">{{ course.course_code }}</span>
                 <span class="course-title">{{ course.course_title }}</span>
@@ -202,7 +210,7 @@
           <th mat-header-cell *matHeaderCellDef class="table-header">
             Course Title
           </th>
-          <td mat-cell *matCellDef="let element" class="table-cell">
+          <td mat-cell *matCellDef="let element" class="table-cell title-cell">
             {{ element.course_title }}
           </td>
         </ng-container>
@@ -272,11 +280,15 @@
           </td>
         </ng-container>
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: displayedColumns"
+          [@rowAdditionAnimation]
+        ></tr>
 
         <tr class="mat-row" *matNoDataRow>
           <td class="mat-cell" colspan="9">
-            <div class="no-data-text">
+            <div class="no-data-text" [@fadeAnimation]>
               <span mat-symbol="info"></span>
               <span>No preferences added yet.</span>
             </div>

--- a/frontend/src/app/core/components/faculty/preferences/preferences.component.html
+++ b/frontend/src/app/core/components/faculty/preferences/preferences.component.html
@@ -85,6 +85,7 @@
             @for (course of filteredSearchResults; track course.course_id) {
             <div
               class="course-card pop"
+              (click)="addCourseToTable(course)"
               matRipple
             >
               <div class="course-info">
@@ -94,7 +95,6 @@
               <button
                 mat-icon-button
                 class="add-button"
-                (click)="addCourseToTable(course)"
               >
                 <span mat-symbol="add" variant="outlined" size="20px"></span>
               </button>
@@ -141,6 +141,7 @@
             course)) {
             <div
               class="course-card pop"
+              (click)="addCourseToTable(course)"
               matRipple
             >
               <div class="course-info">
@@ -150,7 +151,6 @@
               <button
                 mat-icon-button
                 class="add-button"
-                (click)="addCourseToTable(course)"
               >
                 <span mat-symbol="add" variant="outlined" size="20px"></span>
               </button>

--- a/frontend/src/app/core/components/faculty/preferences/preferences.component.scss
+++ b/frontend/src/app/core/components/faculty/preferences/preferences.component.scss
@@ -17,7 +17,6 @@
 
   .disabled {
     opacity: 0.5;
-    pointer-events: none;
     user-select: none;
     transition: opacity 0.3s ease-in-out;
   }
@@ -196,6 +195,15 @@
       margin-bottom: var(--spacing-xs);
       border-radius: var(--border-radius-sm);
       cursor: pointer;
+      transition: all 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+
+      &:hover {
+        transform: scale(0.98);
+      }
+
+      &:active {
+        transform: scale(0.96);
+      }
 
       .course-info,
       .program-info {
@@ -251,6 +259,10 @@
     text-wrap: wrap;
     text-align: center;
     background-color: var(--neutral-light);
+
+    &.title-cell {
+      max-width: var(--spacing-4xl);
+    }
 
     .display-time {
       @include ellipsis;

--- a/frontend/src/app/core/components/faculty/preferences/preferences.component.ts
+++ b/frontend/src/app/core/components/faculty/preferences/preferences.component.ts
@@ -31,7 +31,7 @@ import { ThemeService } from '../../../services/theme/theme.service';
 import { PreferencesService, Program, Course, YearLevel } from '../../../services/faculty/preference/preferences.service';
 import { CookieService } from 'ngx-cookie-service';
 
-import { fadeAnimation, cardEntranceAnimation } from '../../../animations/animations';
+import { fadeAnimation, cardEntranceAnimation, rowAdditionAnimation } from '../../../animations/animations';
 
 interface TableData extends Course {
   preferredDay: string;
@@ -69,7 +69,7 @@ interface TableData extends Course {
   styleUrls: ['./preferences.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [PreferencesService],
-  animations: [fadeAnimation, cardEntranceAnimation],
+  animations: [fadeAnimation, cardEntranceAnimation, rowAdditionAnimation],
 })
 export class PreferencesComponent implements OnInit, AfterViewInit, OnDestroy {
   showSidenav = false;

--- a/frontend/src/app/core/services/admin/reports/reports.service.ts
+++ b/frontend/src/app/core/services/admin/reports/reports.service.ts
@@ -19,6 +19,13 @@ export class ReportsService {
       .pipe(catchError(this.handleError));
   }
 
+  // Room Schedules Report
+  getRoomSchedulesReport(): Observable<any> {
+    return this.http
+      .get(`${this.baseUrl}/room-schedules-report`)
+      .pipe(catchError(this.handleError));
+  }
+
   private handleError(error: HttpErrorResponse) {
     console.error('An error occurred:', error);
     return throwError(

--- a/frontend/src/app/core/services/admin/reports/reports.service.ts
+++ b/frontend/src/app/core/services/admin/reports/reports.service.ts
@@ -26,6 +26,13 @@ export class ReportsService {
       .pipe(catchError(this.handleError));
   }
 
+  // Program Schedules Report
+  getProgramSchedulesReport(): Observable<any> {
+    return this.http
+      .get(`${this.baseUrl}/program-schedules-report`)
+      .pipe(catchError(this.handleError));
+  }
+
   private handleError(error: HttpErrorResponse) {
     console.error('An error occurred:', error);
     return throwError(

--- a/frontend/src/app/shared/dialog-generic/dialog-generic.component.scss
+++ b/frontend/src/app/shared/dialog-generic/dialog-generic.component.scss
@@ -8,7 +8,7 @@
 .custom-dialog-title {
   font-size: var(--font-size-xl);
   color: var(--primary-text);
-  font-weight: 500;
+  font-weight: 600;
   font-family: "Inter Tight", sans-serif;
 }
 

--- a/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.html
+++ b/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.html
@@ -24,6 +24,7 @@
   <div class="dialog-schedule-calendar-container" [@fadeAnimation]>
     <app-schedule-timeline
       [scheduleData]="scheduleData"
+      [entity]="data.entity"
     ></app-schedule-timeline>
   </div>
 

--- a/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.html
+++ b/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.html
@@ -7,8 +7,17 @@
   } @else {
   <!-- Schedule Title -->
   <div class="entity-info" [@fadeAnimation]>
-    <h2 class="dialog-title">{{ title }}</h2>
-    <span class="dialog-subtitle">{{ subtitle }}</span>
+    <!--Schedule title-->
+    <div class="schedule-title">
+      <h2 class="dialog-title">{{ title }}</h2>
+      <span class="dialog-subtitle">{{ subtitle }}</span>
+    </div>
+    <!--Schedule badge-->
+    <div class="schedule-badge">
+      <span class="badge-text">
+        <span mat-symbol="date_range"></span>Official Schedule</span
+      >
+    </div>
   </div>
 
   <!-- Schedule Calendar Container -->

--- a/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.html
+++ b/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.html
@@ -7,26 +7,43 @@
   } @else {
   <!-- Schedule Title -->
   <div class="entity-info" [@fadeAnimation]>
-    <!--Schedule title-->
+    <!-- Schedule Title Container -->
     <div class="schedule-title">
       <h2 class="dialog-title">{{ title }}</h2>
       <span class="dialog-subtitle">{{ subtitle }}</span>
     </div>
-    <!--Schedule badge-->
+    <!-- Schedule Badge -->
     <div class="schedule-badge">
       <span class="badge-text">
-        <span mat-symbol="date_range"></span>Official Schedule</span
-      >
+        <span mat-symbol="date_range"></span>Official Schedule
+      </span>
     </div>
   </div>
 
-  <!-- Schedule Calendar Container -->
-  <div class="dialog-schedule-calendar-container" [@fadeAnimation]>
+  <!-- Multiple Schedule -->
+  @if (scheduleGroups && scheduleGroups.length > 0) {
+  <div class="multiple-schedules-container">
+    @for (group of scheduleGroups; track group) {
+    <div class="schedule-group">
+      <h3 class="group-title">{{ group.title }}</h3>
+      <app-schedule-timeline
+        [scheduleData]="group.scheduleData"
+        [entity]="data.entity"
+      ></app-schedule-timeline>
+    </div>
+    }
+  </div>
+  }
+
+  <!-- Single Schedule -->
+  @if (!scheduleGroups) {
+  <div class="single-schedule-container" [@fadeAnimation]>
     <app-schedule-timeline
       [scheduleData]="scheduleData"
       [entity]="data.entity"
     ></app-schedule-timeline>
   </div>
+  }
 
   <!-- Action buttons -->
   <div class="dialog-actions" [@fadeAnimation]>

--- a/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.html
+++ b/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.html
@@ -22,7 +22,7 @@
 
   <!-- Schedule Calendar Container -->
   <div class="dialog-schedule-calendar-container" [@fadeAnimation]>
-    <!--The weekly schedule will be displayed here-->
+    <app-schedule-timeline [scheduleData]="data.entityData"></app-schedule-timeline>
   </div>
 
   <!-- Action buttons -->

--- a/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.html
+++ b/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.html
@@ -22,7 +22,9 @@
 
   <!-- Schedule Calendar Container -->
   <div class="dialog-schedule-calendar-container" [@fadeAnimation]>
-    <app-schedule-timeline [scheduleData]="data.entityData"></app-schedule-timeline>
+    <app-schedule-timeline
+      [scheduleData]="scheduleData"
+    ></app-schedule-timeline>
   </div>
 
   <!-- Action buttons -->

--- a/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.scss
+++ b/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.scss
@@ -47,7 +47,34 @@
   }
 }
 
-.dialog-schedule-calendar-container {
+.multiple-schedules-container {
+  @include flex-layout(
+    $direction: column,
+    $align: stretch,
+    $justify: flex-start,
+    $gap: var(--spacing-xl)
+  );
+  max-height: 70vh;
+  overflow: auto;
+  padding-right: var(--spacing-md);
+
+  .schedule-group {
+    @include flex-layout(
+      $direction: column,
+      $align: stretch,
+      $justify: flex-start,
+      $gap: var(--spacing-xs)
+    );
+    border-radius: var(--border-radius-md);
+
+    .group-title {
+      @include reset-styles;
+      font-weight: 600;
+    }
+  }
+}
+
+.single-schedule-container {
   @include flex-layout(
     $direction: column,
     $align: stretch,

--- a/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.scss
+++ b/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.scss
@@ -11,14 +11,39 @@
   height: 100%;
 }
 
-.dialog-title {
-  @include reset-styles;
-  font-weight: 600;
-  color: var(--primary-text);
-}
+.entity-info {
+  @include flex-layout(
+    $align: stretch,
+    $justify: space-between,
+    $gap: var(--spacing-xxs)
+  );
 
-.dialog-subtitle {
-  color: var(--primary-text);
+  .schedule-title {
+    .dialog-title {
+      @include reset-styles;
+      font-weight: 600;
+      color: var(--primary-text);
+    }
+
+    .dialog-subtitle {
+      color: var(--primary-text);
+    }
+  }
+
+  .schedule-badge {
+    .badge-text {
+      @include flex-layout($gap: var(--spacing-xxs));
+      @include gradient-primary(315deg);
+      border-radius: var(--border-radius-lg);
+      padding: var(--spacing-xxs) var(--spacing-sm);
+      font-size: var(--font-size-sm);
+      color: white;
+
+      span[mat-symbol] {
+        font-size: var(--font-size-base);
+      }
+    }
+  }
 }
 
 .dialog-schedule-calendar-container {

--- a/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.scss
+++ b/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.scss
@@ -35,8 +35,9 @@
       @include flex-layout($gap: var(--spacing-xxs));
       @include gradient-primary(315deg);
       border-radius: var(--border-radius-lg);
-      padding: var(--spacing-xxs) var(--spacing-sm);
+      padding: var(--spacing-xs) var(--spacing-sm);
       font-size: var(--font-size-sm);
+      font-weight: 500;
       color: white;
 
       span[mat-symbol] {

--- a/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.ts
+++ b/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.ts
@@ -8,6 +8,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatSymbolDirective } from '../../core/imports/mat-symbol.directive';
 
 import { LoadingComponent } from '../loading/loading.component';
+import { ScheduleTimelineComponent } from '../schedule-timeline/schedule-timeline.component';
 
 import { fadeAnimation } from '../../core/animations/animations';
 
@@ -25,6 +26,7 @@ interface ViewScheduleDialogData {
   imports: [
     CommonModule,
     LoadingComponent,
+    ScheduleTimelineComponent,
     MatTableModule,
     MatButtonModule,
     MatIconModule,

--- a/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.ts
+++ b/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.ts
@@ -5,6 +5,7 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatTableModule } from '@angular/material/table';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatSymbolDirective } from '../../core/imports/mat-symbol.directive';
 
 import { LoadingComponent } from '../loading/loading.component';
 
@@ -27,6 +28,7 @@ interface ViewScheduleDialogData {
     MatTableModule,
     MatButtonModule,
     MatIconModule,
+    MatSymbolDirective,
   ],
   templateUrl: './dialog-view-schedule.component.html',
   styleUrl: './dialog-view-schedule.component.scss',

--- a/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.ts
+++ b/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.ts
@@ -40,6 +40,7 @@ export class DialogViewScheduleComponent implements OnInit {
   title: string = '';
   subtitle: string = '';
   isLoading = true;
+  scheduleData: any;
 
   constructor(
     public dialogRef: MatDialogRef<DialogViewScheduleComponent>,
@@ -48,6 +49,7 @@ export class DialogViewScheduleComponent implements OnInit {
 
   ngOnInit(): void {
     this.initializeScheduleTitle();
+    this.scheduleData = this.data.entityData;
   }
 
   private initializeScheduleTitle(): void {

--- a/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.ts
+++ b/frontend/src/app/shared/dialog-view-schedule/dialog-view-schedule.component.ts
@@ -12,12 +12,18 @@ import { ScheduleTimelineComponent } from '../schedule-timeline/schedule-timelin
 
 import { fadeAnimation } from '../../core/animations/animations';
 
+interface ScheduleGroup {
+  title: string;
+  scheduleData: any;
+}
+
 interface ViewScheduleDialogData {
   entity: string;
   entityData?: any;
   customTitle?: string;
   academicYear?: string;
   semester?: number;
+  scheduleGroups?: ScheduleGroup[];
 }
 
 @Component({
@@ -33,7 +39,7 @@ interface ViewScheduleDialogData {
     MatSymbolDirective,
   ],
   templateUrl: './dialog-view-schedule.component.html',
-  styleUrl: './dialog-view-schedule.component.scss',
+  styleUrls: ['./dialog-view-schedule.component.scss'],
   animations: [fadeAnimation],
 })
 export class DialogViewScheduleComponent implements OnInit {
@@ -41,6 +47,7 @@ export class DialogViewScheduleComponent implements OnInit {
   subtitle: string = '';
   isLoading = true;
   scheduleData: any;
+  scheduleGroups?: ScheduleGroup[];
 
   constructor(
     public dialogRef: MatDialogRef<DialogViewScheduleComponent>,
@@ -49,7 +56,12 @@ export class DialogViewScheduleComponent implements OnInit {
 
   ngOnInit(): void {
     this.initializeScheduleTitle();
-    this.scheduleData = this.data.entityData;
+    if (this.data.scheduleGroups && this.data.scheduleGroups.length > 0) {
+      this.scheduleGroups = this.data.scheduleGroups;
+    } else {
+      this.scheduleData = this.data.entityData;
+    }
+    this.isLoading = false;
   }
 
   private initializeScheduleTitle(): void {
@@ -59,7 +71,8 @@ export class DialogViewScheduleComponent implements OnInit {
   private setTitleAndSubtitle(): void {
     const { customTitle, entityData, academicYear, semester } = this.data;
 
-    this.title = customTitle ?? entityData?.name ?? entityData?.title;
+    this.title =
+      customTitle ?? entityData?.name ?? entityData?.title ?? 'Schedule';
     this.subtitle =
       academicYear && semester
         ? `For Academic Year ${academicYear}, ${semester}`

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.html
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.html
@@ -1,0 +1,25 @@
+<div class="schedule-timeline-container">
+  <!--Schedule Timeline Table-->
+  <table class="schedule-timeline-table">
+    <!--Schedule Timeline header-->
+    <thead class="schedule-timeline-table-header">
+      <tr>
+        <th></th>
+        @for (day of days; track day) {
+        <th>{{ day }}</th>
+        }
+      </tr>
+    </thead>
+    <!--Schedule Timeline Body-->
+    <tbody class="schedule-timeline-table-body">
+      @for (slot of timeSlots; track slot) {
+      <tr>
+        <td class="time-slot">{{ slot.time }}</td>
+        @for (day of days; track day) {
+        <td class="schedule-cell"></td>
+        }
+      </tr>
+      }
+    </tbody>
+  </table>
+</div>

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.html
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.html
@@ -22,8 +22,8 @@
             <div 
               class="schedule-content"
               [style.height.px]="getScheduleBlockHeight(day, i)"
+              [innerHTML]="getScheduleBlockContent(day,i)"
             >
-              {{ getScheduleBlockContent(day, i) }}
             </div>
           }
         </td>

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.html
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.html
@@ -1,7 +1,5 @@
 <div class="schedule-timeline-container">
-  <!--Schedule Timeline Table-->
   <table class="schedule-timeline-table">
-    <!--Schedule Timeline header-->
     <thead class="schedule-timeline-table-header">
       <tr>
         <th></th>
@@ -10,13 +8,25 @@
         }
       </tr>
     </thead>
-    <!--Schedule Timeline Body-->
     <tbody class="schedule-timeline-table-body">
-      @for (slot of timeSlots; track slot) {
+      @for (slot of timeSlots; track slot; let i = $index) {
       <tr>
         <td class="time-slot">{{ slot.time }}</td>
         @for (day of days; track day) {
-        <td class="schedule-cell"></td>
+        <td
+          class="schedule-cell"
+          [ngClass]="{'schedule-block-start': isScheduleBlockStart(day, i)}"
+          [ngStyle]="getScheduleBlockStyle(day, i)"
+        >
+          @if (isScheduleBlockStart(day, i)) {
+            <div 
+              class="schedule-content"
+              [style.height.px]="getScheduleBlockHeight(day, i)"
+            >
+              {{ getScheduleBlockContent(day, i) }}
+            </div>
+          }
+        </td>
         }
       </tr>
       }

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.html
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.html
@@ -15,16 +15,46 @@
         @for (day of days; track day) {
         <td
           class="schedule-cell"
-          [ngClass]="{'schedule-block-start': isScheduleBlockStart(day, i)}"
+          [ngClass]="{ 'schedule-block-start': isScheduleBlockStart(day, i) }"
           [ngStyle]="getScheduleBlockStyle(day, i)"
         >
           @if (isScheduleBlockStart(day, i)) {
-            <div 
-              class="schedule-content"
-              [style.height.px]="getScheduleBlockHeight(day, i)"
-              [innerHTML]="getScheduleBlockContent(day,i)"
-            >
+          <div
+            class="schedule-content"
+            [style.height.px]="getScheduleBlockHeight(day, i)"
+            [ngClass]="getDayClass(day)"
+          >
+            <!-- Course Code and Course Title (Visible for all entities) -->
+            <div class="course">
+              <span class="course-text">
+                {{ getBlockProperty(day, i, "courseCode") }}<br />
+                {{ getBlockProperty(day, i, "courseTitle") }}
+              </span>
             </div>
+            <!-- Program Details (Visible for faculty and room) -->
+            @if (entity === 'faculty' || entity === 'room') {
+            <div>
+              ({{ getBlockProperty(day, i, "program") }}
+              {{ getBlockProperty(day, i, "yearLevel") }}-{{
+                getBlockProperty(day, i, "section")
+              }})
+            </div>
+            }
+            <!-- Faculty Name (Visible for program and room) -->
+            @if (entity === 'program' || entity === 'room') {
+            <div>
+              {{ getBlockProperty(day, i, "facultyName") }}
+            </div>
+            }
+            <!-- Room Code (Visible for faculty and program) -->
+            @if (entity === 'faculty' || entity === 'program') {
+            <div>
+              {{ getBlockProperty(day, i, "roomCode") }}
+            </div>
+            }
+            <!-- Time (Visible for all entities) -->
+            <div>{{ getFormattedTime(day, i) }}</div>
+          </div>
           }
         </td>
         }

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.scss
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.scss
@@ -41,7 +41,7 @@
         border-right: 1px solid var(--neutral-fade);
         min-width: 5rem;
         max-width: 5rem;
-        height: 1rem;
+        height: 1.5rem;
         position: relative;
       }
 

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.scss
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.scss
@@ -10,8 +10,10 @@
 
   .schedule-timeline-table {
     width: 100%;
-    border-collapse: collapse;
+    border-collapse: separate;
+    border-spacing: 0;
     background-color: var(--neutral-space);
+    position: relative;
 
     th,
     td {
@@ -22,23 +24,27 @@
     .schedule-timeline-table-header {
       @include sticky;
       background-color: var(--primary-one);
+      z-index: 2;
 
       th {
         color: white;
         padding: var(--spacing-xs);
         border-right: 1px solid var(--neutral-fade);
-        border-bottom: 1px solid var(--neutral-fade); /* Bottom border between header and body */
+        border-bottom: 1px solid var(--neutral-fade);
       }
     }
 
     .schedule-timeline-table-body {
       td {
-        padding: var(--spacing-xxxs);
-        border-bottom: 1px solid var(--neutral-fade); /* Border between rows */
-        border-right: 1px solid var(--neutral-fade); /* Border between columns */
+        padding: 0;
+        border-bottom: 1px solid var(--neutral-fade);
+        border-right: 1px solid var(--neutral-fade);
+        min-width: 5rem;
+        max-width: 5rem;
+        height: 2rem;
+        position: relative;
       }
 
-      /* Remove the right border from the last column to avoid border on the side */
       tr td:last-child {
         border-right: none;
       }
@@ -47,17 +53,48 @@
         position: sticky;
         left: 0;
         font-weight: 500;
-        border-right: 1px solid var(--neutral-fade); /* Right border for the time slot column */
-      }
-
-      /* Remove the border-right for the last cell in the time slot column */
-      tr td.time-slot {
         border-right: 1px solid var(--neutral-fade);
+        background-color: var(--neutral-space);
+        z-index: 1;
+        padding: var(--spacing-xxxs);
       }
 
       .schedule-cell {
-        min-width: 100px;
-        height: 30px;
+        position: relative;
+
+        &.schedule-block-start {
+          border-bottom: none;
+
+          & + .schedule-cell {
+            border-top: none;
+          }
+
+          .schedule-content {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            z-index: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            white-space: pre-wrap;
+            word-break: break-word;
+            font-size: 0.875rem;
+            padding: 4px;
+            pointer-events: none;
+          }
+        }
+
+        &[style*="background-color"] {
+          border-bottom: none;
+          border-top: none;
+
+          & + .schedule-cell[style*="background-color"] {
+            border-left: none;
+          }
+        }
       }
     }
   }

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.scss
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.scss
@@ -75,15 +75,16 @@
             left: 0;
             right: 0;
             z-index: 1;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            text-align: center;
+            @include flex-layout(
+              $direction: column,
+              $align: center,
+              $justify: center,
+              $gap: var(--spacing-md)
+            );
             white-space: pre-wrap;
             word-break: break-word;
-            font-size: 0.875rem;
-            padding: 4px;
-            pointer-events: none;
+            font-size: var(--font-size-sm);
+            padding: 0 var(--spacing-xs);
           }
         }
 

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.scss
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.scss
@@ -1,5 +1,21 @@
 @import "../../../styles/mixins.scss";
 
+$day-colors: (
+  monday: var(--primary-text),
+  tuesday: var(--secondary-text),
+  wednesday: var(--blue-primary),
+  thursday: var(--aqua-primary),
+  friday: var(--purple-primary),
+  saturday: var(--green-primary),
+  sunday: var(--primary-text),
+);
+
+@each $day, $color in $day-colors {
+  .schedule-content.schedule-#{$day} .course {
+    color: #{$color};
+  }
+}
+
 .schedule-timeline-container {
   @include hide-scrollbar;
   height: 100%;
@@ -85,6 +101,10 @@
             word-break: break-word;
             font-size: var(--font-size-sm);
             padding: 0 var(--spacing-xs);
+
+            .course-text {
+              font-weight: 600;
+            }
           }
         }
 

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.scss
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.scss
@@ -66,8 +66,6 @@ $day-colors: (
       }
 
       .time-slot {
-        position: sticky;
-        left: 0;
         font-weight: 500;
         border-right: 1px solid var(--neutral-fade);
         background-color: var(--neutral-space);
@@ -76,6 +74,8 @@ $day-colors: (
       }
 
       .schedule-cell {
+        max-width: 6rem;
+        min-width: 6rem;
         position: relative;
 
         &.schedule-block-start {

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.scss
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.scss
@@ -1,0 +1,64 @@
+@import "../../../styles/mixins.scss";
+
+.schedule-timeline-container {
+  @include hide-scrollbar;
+  height: 100%;
+  width: 100%;
+  overflow-y: auto;
+  max-height: 60vh;
+  border-radius: var(--border-radius-md);
+
+  .schedule-timeline-table {
+    width: 100%;
+    border-collapse: collapse;
+    background-color: var(--neutral-space);
+
+    th,
+    td {
+      text-align: center;
+      font-weight: 500;
+    }
+
+    .schedule-timeline-table-header {
+      @include sticky;
+      background-color: var(--primary-one);
+
+      th {
+        color: white;
+        padding: var(--spacing-xs);
+        border-right: 1px solid var(--neutral-fade);
+        border-bottom: 1px solid var(--neutral-fade); /* Bottom border between header and body */
+      }
+    }
+
+    .schedule-timeline-table-body {
+      td {
+        padding: var(--spacing-xxxs);
+        border-bottom: 1px solid var(--neutral-fade); /* Border between rows */
+        border-right: 1px solid var(--neutral-fade); /* Border between columns */
+      }
+
+      /* Remove the right border from the last column to avoid border on the side */
+      tr td:last-child {
+        border-right: none;
+      }
+
+      .time-slot {
+        position: sticky;
+        left: 0;
+        font-weight: 500;
+        border-right: 1px solid var(--neutral-fade); /* Right border for the time slot column */
+      }
+
+      /* Remove the border-right for the last cell in the time slot column */
+      tr td.time-slot {
+        border-right: 1px solid var(--neutral-fade);
+      }
+
+      .schedule-cell {
+        min-width: 100px;
+        height: 30px;
+      }
+    }
+  }
+}

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.scss
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.scss
@@ -41,7 +41,7 @@
         border-right: 1px solid var(--neutral-fade);
         min-width: 5rem;
         max-width: 5rem;
-        height: 2rem;
+        height: 1rem;
         position: relative;
       }
 

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.spec.ts
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ScheduleTimelineComponent } from './schedule-timeline.component';
+
+describe('ScheduleTimelineComponent', () => {
+  let component: ScheduleTimelineComponent;
+  let fixture: ComponentFixture<ScheduleTimelineComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ScheduleTimelineComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ScheduleTimelineComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.ts
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.ts
@@ -160,7 +160,7 @@ export class ScheduleTimelineComponent implements OnInit {
         slotIndex < b.startSlot + b.duration
     );
     if (block && slotIndex === block.startSlot) {
-      return `${block.courseCode} - ${block.courseTitle}\n${block.roomCode}\n${block.program} ${block.yearLevel}-${block.section}`;
+      return `${block.courseCode}\n${block.courseTitle}\n\n${block.roomCode}\n\n${block.program} ${block.yearLevel}-${block.section}`;
     }
     return '';
   }

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.ts
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.ts
@@ -176,9 +176,26 @@ export class ScheduleTimelineComponent implements OnInit {
         const formattedEndTime = this.formatTimeTo12Hour(schedule.end_time);
 
         if (this.entity === 'faculty') {
-          return `${block.courseCode}\n${block.courseTitle}\n(${block.program} ${block.yearLevel}-${block.section})\n\n${block.roomCode}\n\n${formattedStartTime} - ${formattedEndTime}`;
+          return `
+            <div class="course"><strong>${block.courseCode}<br>${block.courseTitle}</strong></div>
+            <div>(${block.program}${block.yearLevel}-${block.section})</div>
+            <div>${block.roomCode}</div>
+            <div>${formattedStartTime} - ${formattedEndTime}</div>
+          `;
         } else if (this.entity === 'room') {
-          return `${block.courseCode}\n${block.courseTitle}\n(${block.program} ${block.yearLevel}-${block.section})\n\n${block.facultyName}\n\n${formattedStartTime} - ${formattedEndTime}`;
+          return `
+            <div class="course"><strong>${block.courseCode}<br>${block.courseTitle}</strong></div>
+            <div>(${block.program}${block.yearLevel}-${block.section})</div>
+            <div>${block.facultyName}</div>
+            <div>${formattedStartTime} - ${formattedEndTime}</div>
+          `;
+        } else if (this.entity === 'program') {
+          return `
+            <div class="course"><strong>${block.courseCode}<br>${block.courseTitle}</strong></div>
+            <div>${block.facultyName}</div>
+            <div>${formattedStartTime} - ${formattedEndTime}</div>
+            <div>${block.roomCode}</div>
+          `;
         }
       }
     }

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.ts
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.ts
@@ -117,7 +117,7 @@ export class ScheduleTimelineComponent implements OnInit {
       (b) => b.day === day && slotIndex === b.startSlot
     );
     if (block) {
-      return block.duration * 22 - 2; // TODO: adjust this in the future idk
+      return block.duration * 26 - 2; // TODO: adjust this in the future idk
     }
     return 0;
   }
@@ -171,7 +171,7 @@ export class ScheduleTimelineComponent implements OnInit {
         const formattedStartTime = this.formatTimeTo12Hour(schedule.start_time);
         const formattedEndTime = this.formatTimeTo12Hour(schedule.end_time);
         
-        return `${block.courseCode}\n${block.courseTitle}\n\n${block.roomCode}\n\n${block.program} ${block.yearLevel}-${block.section}\n\n${formattedStartTime} - ${formattedEndTime}`;
+        return `${block.courseCode}\n${block.courseTitle}\n(${block.program} ${block.yearLevel}-${block.section})\n\n${block.roomCode}\n\n${formattedStartTime} - ${formattedEndTime}`;
       }
     }
     return '';

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.ts
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.ts
@@ -159,9 +159,31 @@ export class ScheduleTimelineComponent implements OnInit {
         slotIndex >= b.startSlot &&
         slotIndex < b.startSlot + b.duration
     );
+
     if (block && slotIndex === block.startSlot) {
-      return `${block.courseCode}\n${block.courseTitle}\n\n${block.roomCode}\n\n${block.program} ${block.yearLevel}-${block.section}`;
+      const schedule = this.scheduleData.find(
+        (schedule: any) =>
+          schedule.day === day &&
+          this.convertTimeToMinutes(schedule.start_time) === this.timeSlots[slotIndex].minutes
+      );
+  
+      if (schedule) {
+        const formattedStartTime = this.formatTimeTo12Hour(schedule.start_time);
+        const formattedEndTime = this.formatTimeTo12Hour(schedule.end_time);
+        
+        return `${block.courseCode}\n${block.courseTitle}\n\n${block.roomCode}\n\n${block.program} ${block.yearLevel}-${block.section}\n\n${formattedStartTime} - ${formattedEndTime}`;
+      }
     }
     return '';
   }
+  
+  
+  private formatTimeTo12Hour(time: string): string {
+    let [hours, minutes] = time.split(':').map(Number);
+    const ampm = hours >= 12 ? 'PM' : 'AM';
+    hours = hours % 12 || 12;
+    const formattedMinutes = minutes.toString().padStart(2, '0');
+    return `${hours}:${formattedMinutes} ${ampm}`;
+  }
+  
 }

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.ts
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.ts
@@ -1,0 +1,50 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+interface TimeSlot {
+  time: string;
+}
+
+@Component({
+  selector: 'app-schedule-timeline',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './schedule-timeline.component.html',
+  styleUrls: ['./schedule-timeline.component.scss'],
+})
+export class ScheduleTimelineComponent implements OnInit {
+  @Input() scheduleData: any; 
+
+  days: string[] = [
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+    'Sunday',
+  ];
+  timeSlots: TimeSlot[] = [];
+
+  ngOnInit() {
+    this.generateTimeSlots();
+  }
+
+  private generateTimeSlots() {
+    const startTime = 7 * 60;
+    const endTime = 21 * 60;
+    const interval = 30;
+
+    for (let time = startTime; time <= endTime; time += interval) {
+      const hours = Math.floor(time / 60);
+      const minutes = time % 60;
+      const ampm = hours >= 12 ? 'PM' : 'AM';
+      const formattedHours = hours % 12 || 12;
+      const formattedTime = `${formattedHours
+        .toString()
+        .padStart(2, '0')}:${minutes.toString().padStart(2, '0')} ${ampm}`;
+
+      this.timeSlots.push({ time: formattedTime });
+    }
+  }
+}

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.ts
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.ts
@@ -3,6 +3,19 @@ import { CommonModule } from '@angular/common';
 
 interface TimeSlot {
   time: string;
+  minutes: number;
+}
+
+interface ScheduleBlock {
+  day: string;
+  startSlot: number;
+  duration: number;
+  courseCode: string;
+  courseTitle: string;
+  roomCode: string;
+  program: string;
+  yearLevel: number;
+  section: string;
 }
 
 @Component({
@@ -13,7 +26,7 @@ interface TimeSlot {
   styleUrls: ['./schedule-timeline.component.scss'],
 })
 export class ScheduleTimelineComponent implements OnInit {
-  @Input() scheduleData: any; 
+  @Input() scheduleData: any;
 
   days: string[] = [
     'Monday',
@@ -25,9 +38,13 @@ export class ScheduleTimelineComponent implements OnInit {
     'Sunday',
   ];
   timeSlots: TimeSlot[] = [];
+  scheduleBlocks: ScheduleBlock[] = [];
 
   ngOnInit() {
+    console.log('Schedule Data:', this.scheduleData);
     this.generateTimeSlots();
+    this.processScheduleData();
+    console.log('Processed Schedule Blocks:', this.scheduleBlocks);
   }
 
   private generateTimeSlots() {
@@ -44,7 +61,103 @@ export class ScheduleTimelineComponent implements OnInit {
         .toString()
         .padStart(2, '0')}:${minutes.toString().padStart(2, '0')} ${ampm}`;
 
-      this.timeSlots.push({ time: formattedTime });
+      this.timeSlots.push({ time: formattedTime, minutes: time });
     }
+  }
+
+  private processScheduleData() {
+    console.log('Processing schedule data:', this.scheduleData);
+    if (Array.isArray(this.scheduleData) && this.scheduleData.length > 0) {
+      this.scheduleData.forEach((schedule: any) => {
+        const startTime = this.convertTimeToMinutes(schedule.start_time);
+        const endTime = this.convertTimeToMinutes(schedule.end_time);
+        const startSlot = this.findTimeSlotIndex(startTime);
+        
+        // Correctly calculate duration, adding an extra timeslot if there's a remainder
+        const duration = Math.ceil((endTime - startTime) / 30);
+  
+        // Ensure that if endTime is perfectly divisible by 30 after startTime, we add an extra slot.
+        const hasExtraSlot = (endTime - startTime) % 30 === 0 && endTime !== startTime;
+        const adjustedDuration = hasExtraSlot ? duration + 1 : duration;
+  
+        this.scheduleBlocks.push({
+          day: schedule.day,
+          startSlot: startSlot,
+          duration: adjustedDuration,
+          courseCode: schedule.course_details.course_code,
+          courseTitle: schedule.course_details.course_title,
+          roomCode: schedule.room_code,
+          program: schedule.program_code,
+          yearLevel: schedule.year_level,
+          section: schedule.section_name,
+        });
+      });
+    } else {
+      console.warn('No schedules found or invalid data structure:', this.scheduleData);
+    }
+  }  
+  
+  private convertTimeToMinutes(time: string): number {
+    const [hours, minutes] = time.split(':').map(Number);
+    return hours * 60 + minutes;
+  }
+
+  private findTimeSlotIndex(minutes: number): number {
+    return this.timeSlots.findIndex(slot => slot.minutes >= minutes);
+  }
+
+  isScheduleBlockStart(day: string, slotIndex: number): boolean {
+    return this.scheduleBlocks.some(
+      b => b.day === day && slotIndex === b.startSlot
+    );
+  }
+  
+  getScheduleBlockHeight(day: string, slotIndex: number): number {
+    const block = this.scheduleBlocks.find(
+      b => b.day === day && slotIndex === b.startSlot
+    );
+    if (block) {
+      // Calculate exact height based on cell height and duration
+      return (block.duration * 32) - 2; // 32px is the cell height (2rem), subtract 2px for borders
+    }
+    return 0;
+  }
+  
+  // Update the getScheduleBlockStyle method:
+  getScheduleBlockStyle(day: string, slotIndex: number): any {
+    const block = this.scheduleBlocks.find(
+      b => b.day === day && slotIndex >= b.startSlot && slotIndex < b.startSlot + b.duration
+    );
+    if (block) {
+      const baseStyle = {
+        'background-color': 'var(--primary-fade)',
+        'border-left': '1px solid var(--primary-one)',
+        'border-right': '1px solid var(--primary-one)',
+      };
+  
+      if (slotIndex === block.startSlot) {
+        return {
+          ...baseStyle,
+          'border-top': '1px solid var(--primary-one)',
+        };
+      } else if (slotIndex === block.startSlot + block.duration - 1) {
+        return {
+          ...baseStyle,
+          'border-bottom': '1px solid var(--primary-one)',
+        };
+      }
+      return baseStyle;
+    }
+    return {};
+  }
+  
+  getScheduleBlockContent(day: string, slotIndex: number): string {
+    const block = this.scheduleBlocks.find(
+      b => b.day === day && slotIndex >= b.startSlot && slotIndex < b.startSlot + b.duration
+    );
+    if (block && slotIndex === block.startSlot) {
+      return `${block.courseCode} - ${block.courseTitle}\n${block.roomCode}\n${block.program} ${block.yearLevel}-${block.section}`;
+    }
+    return '';
   }
 }

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.ts
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.ts
@@ -13,6 +13,7 @@ interface ScheduleBlock {
   courseCode: string;
   courseTitle: string;
   roomCode: string;
+  facultyName: string;
   program: string;
   yearLevel: number;
   section: string;
@@ -27,6 +28,7 @@ interface ScheduleBlock {
 })
 export class ScheduleTimelineComponent implements OnInit {
   @Input() scheduleData: any;
+  @Input() entity!: string;
 
   days: string[] = [
     'Monday',
@@ -84,6 +86,7 @@ export class ScheduleTimelineComponent implements OnInit {
           courseCode: schedule.course_details.course_code,
           courseTitle: schedule.course_details.course_title,
           roomCode: schedule.room_code,
+          facultyName: schedule.faculty_name,
           program: schedule.program_code,
           yearLevel: schedule.year_level,
           section: schedule.section_name,
@@ -164,20 +167,24 @@ export class ScheduleTimelineComponent implements OnInit {
       const schedule = this.scheduleData.find(
         (schedule: any) =>
           schedule.day === day &&
-          this.convertTimeToMinutes(schedule.start_time) === this.timeSlots[slotIndex].minutes
+          this.convertTimeToMinutes(schedule.start_time) ===
+            this.timeSlots[slotIndex].minutes
       );
-  
+
       if (schedule) {
         const formattedStartTime = this.formatTimeTo12Hour(schedule.start_time);
         const formattedEndTime = this.formatTimeTo12Hour(schedule.end_time);
-        
-        return `${block.courseCode}\n${block.courseTitle}\n(${block.program} ${block.yearLevel}-${block.section})\n\n${block.roomCode}\n\n${formattedStartTime} - ${formattedEndTime}`;
+
+        if (this.entity === 'faculty') {
+          return `${block.courseCode}\n${block.courseTitle}\n(${block.program} ${block.yearLevel}-${block.section})\n\n${block.roomCode}\n\n${formattedStartTime} - ${formattedEndTime}`;
+        } else if (this.entity === 'room') {
+          return `${block.courseCode}\n${block.courseTitle}\n(${block.program} ${block.yearLevel}-${block.section})\n\n${block.facultyName}\n\n${formattedStartTime} - ${formattedEndTime}`;
+        }
       }
     }
     return '';
   }
-  
-  
+
   private formatTimeTo12Hour(time: string): string {
     let [hours, minutes] = time.split(':').map(Number);
     const ampm = hours >= 12 ? 'PM' : 'AM';
@@ -185,5 +192,4 @@ export class ScheduleTimelineComponent implements OnInit {
     const formattedMinutes = minutes.toString().padStart(2, '0');
     return `${hours}:${formattedMinutes} ${ampm}`;
   }
-  
 }

--- a/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.ts
+++ b/frontend/src/app/shared/schedule-timeline/schedule-timeline.component.ts
@@ -72,14 +72,11 @@ export class ScheduleTimelineComponent implements OnInit {
         const startTime = this.convertTimeToMinutes(schedule.start_time);
         const endTime = this.convertTimeToMinutes(schedule.end_time);
         const startSlot = this.findTimeSlotIndex(startTime);
-        
-        // Correctly calculate duration, adding an extra timeslot if there's a remainder
         const duration = Math.ceil((endTime - startTime) / 30);
-  
-        // Ensure that if endTime is perfectly divisible by 30 after startTime, we add an extra slot.
-        const hasExtraSlot = (endTime - startTime) % 30 === 0 && endTime !== startTime;
+        const hasExtraSlot =
+          (endTime - startTime) % 30 === 0 && endTime !== startTime;
         const adjustedDuration = hasExtraSlot ? duration + 1 : duration;
-  
+
         this.scheduleBlocks.push({
           day: schedule.day,
           startSlot: startSlot,
@@ -93,40 +90,44 @@ export class ScheduleTimelineComponent implements OnInit {
         });
       });
     } else {
-      console.warn('No schedules found or invalid data structure:', this.scheduleData);
+      console.warn(
+        'No schedules found or invalid data structure:',
+        this.scheduleData
+      );
     }
-  }  
-  
+  }
+
   private convertTimeToMinutes(time: string): number {
     const [hours, minutes] = time.split(':').map(Number);
     return hours * 60 + minutes;
   }
 
   private findTimeSlotIndex(minutes: number): number {
-    return this.timeSlots.findIndex(slot => slot.minutes >= minutes);
+    return this.timeSlots.findIndex((slot) => slot.minutes >= minutes);
   }
 
   isScheduleBlockStart(day: string, slotIndex: number): boolean {
     return this.scheduleBlocks.some(
-      b => b.day === day && slotIndex === b.startSlot
+      (b) => b.day === day && slotIndex === b.startSlot
     );
   }
-  
+
   getScheduleBlockHeight(day: string, slotIndex: number): number {
     const block = this.scheduleBlocks.find(
-      b => b.day === day && slotIndex === b.startSlot
+      (b) => b.day === day && slotIndex === b.startSlot
     );
     if (block) {
-      // Calculate exact height based on cell height and duration
-      return (block.duration * 32) - 2; // 32px is the cell height (2rem), subtract 2px for borders
+      return block.duration * 22 - 2; // TODO: adjust this in the future idk
     }
     return 0;
   }
-  
-  // Update the getScheduleBlockStyle method:
+
   getScheduleBlockStyle(day: string, slotIndex: number): any {
     const block = this.scheduleBlocks.find(
-      b => b.day === day && slotIndex >= b.startSlot && slotIndex < b.startSlot + b.duration
+      (b) =>
+        b.day === day &&
+        slotIndex >= b.startSlot &&
+        slotIndex < b.startSlot + b.duration
     );
     if (block) {
       const baseStyle = {
@@ -134,7 +135,7 @@ export class ScheduleTimelineComponent implements OnInit {
         'border-left': '1px solid var(--primary-one)',
         'border-right': '1px solid var(--primary-one)',
       };
-  
+
       if (slotIndex === block.startSlot) {
         return {
           ...baseStyle,
@@ -150,10 +151,13 @@ export class ScheduleTimelineComponent implements OnInit {
     }
     return {};
   }
-  
+
   getScheduleBlockContent(day: string, slotIndex: number): string {
     const block = this.scheduleBlocks.find(
-      b => b.day === day && slotIndex >= b.startSlot && slotIndex < b.startSlot + b.duration
+      (b) =>
+        b.day === day &&
+        slotIndex >= b.startSlot &&
+        slotIndex < b.startSlot + b.duration
     );
     if (block && slotIndex === block.startSlot) {
       return `${block.courseCode} - ${block.courseTitle}\n${block.roomCode}\n${block.program} ${block.yearLevel}-${block.section}`;

--- a/frontend/src/app/shared/table-dialog/table-dialog.component.ts
+++ b/frontend/src/app/shared/table-dialog/table-dialog.component.ts
@@ -308,7 +308,7 @@ export class TableDialogComponent {
     if (this.form.valid) {
       this.isLoading = true;
 
-      const minimumSpinnerDuration = 1000;
+      const minimumSpinnerDuration = 500;
       const startTime = Date.now();
 
       this.dialogRef.disableClose = true;

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -42,6 +42,7 @@
   --line-height-lg: 1.75;
 
   // Spacing
+  --spacing-xxxs: 0.1rem;
   --spacing-xxs: 0.25rem;
   --spacing-xs: 0.5rem;
   --spacing-sm: 0.75rem;


### PR DESCRIPTION
Good evening. This pull request is a culmination of my efforts in the past 4 days to build our reports component for the schedule. I will explain below the architecture of this module and why I think this is a better approach. Kindly read until the end.

- For our `reports component`, we have three sub-components: `report-faculty`, `report-programs`, and `report-rooms`. Each component is injected inside the `router-outlet` directive inside the base `reports` component.

- Each of the sub components is lazily loaded and has its own lifecycle for obvious reasons. So for example, if the user clicks the "Programs" tab for report, we see two network requests: one for the lazily loaded chunk of this component, and the other is our API request for fetching the programs schedule report:

![image](https://github.com/user-attachments/assets/568a8e7c-60a3-4949-9ced-2536df50b75f)

If use clicks the "Rooms" tab, you can see that see identical request pattern:

![image](https://github.com/user-attachments/assets/9d3893f5-f9f0-4124-89bd-9cec3d24cdc6)

When we go to the `scheduling` component, we make three API calls, with `populate-schedules` taking up a comparably sizeable amount of data:

![image](https://github.com/user-attachments/assets/97c661c9-5836-4c26-b003-31f14dc87634)

This is because this API returns all the necessary details needed for scheduling, which is expected. However using this API or a similar API for sub-reports components could lead to slower response in production since we are requesting unnecessary details from the server.

- This is why I created a new controller named `ReportsController` that contains three main methods that return only the necessary API needed for each sub reports component. It has the following API routes:

```php
Route::get('/faculty-schedules-report', [ReportsController::class, 'getFacultySchedulesReport']);
Route::get('/room-schedules-report', [ReportsController::class, 'getRoomSchedulesReport']);
Route::get('/program-schedules-report', [ReportsController::class, 'getProgramSchedulesReport']);
``` 

Each of the API return the precise data only needed by each sub-reports component every time that they are loaded/initialized. For example, the `room-schedules-report` returns the following JSON:

```javascript
{
    "room_schedule_reports": {
        "academic_year_id": 2,
        "year_start": 2024,
        "year_end": 2025,
        "active_semester_id": 1,
        "semester": 1,
        "rooms": [
            {
                "room_id": 1,
                "room_code": "A201",
                "location": "Building A",
                "floor_level": "2nd",
                "capacity": 50,
                "schedules": [
                    {
                        "schedule_id": 7,
                        "day": "Thursday",
                        "start_time": "16:30:00",
                        "end_time": "20:30:00",
                        "faculty_name": "Emmanuel Martinez",
                        "faculty_code": "FA0001TG2024",
                        "program_code": "BSIT-TG",
                        "program_title": "Bachelor of Science in Information Technology",
                        "year_level": 2,
                        "section_name": "1",
                        "course_details": {
                            "course_assignment_id": 47,
                            "course_title": "Data Analytics",
                            "course_code": "COMP104",
                            "lec": 3,
                            "lab": 1,
                            "units": 4,
                            "tuition_hours": 4
                        }
                    }
                ]
            },
           // Other rooms
}
``` 


### Now that we have received the API response and stored it in our observable in the service, our app passes the necessary faculty details as well as the schedule data across three components, as I visualized in this simple diagram:

![image](https://github.com/user-attachments/assets/1d0508bb-50fb-4ecd-9a0d-8086d4be1e85)

And below is the displayed schedule timeline for example, in a specific room:

![image](https://github.com/user-attachments/assets/0768ca7b-d77f-42c6-be37-7c3116d9ff44)

With all this in mind, I decided not to approve pull request #50, as some of the changes it contains go against our component's architecture. However, I appreciate and thank you for all the efforts you contribute to our project, though I never assigned anyone to make changes to our `ReportsController`. Thanks for the understanding. 

After this pull request is approved, I'll be checking out and testing the other changes in the PR #50 regarding the toggling of schedule publishing.

Please test these changes to your local machines and let me know immediately if there are any existing or potential bugs. 