### PR TITLE
assign program to latest curriculum a.y

### DIFF
--- a/backend/app/Http/Controllers/AcademicYearController.php
+++ b/backend/app/Http/Controllers/AcademicYearController.php
@@ -430,7 +430,7 @@ class AcademicYearController extends Controller
     {
         // Start a transaction to ensure atomicity
         DB::beginTransaction();
-
+    
         try {
             // Step 1: Insert into academic_years table
             $academicYear = new AcademicYear();
@@ -438,21 +438,28 @@ class AcademicYearController extends Controller
             $academicYear->year_end = $request->input('year_end');
             $academicYear->is_active = 0; // Set default is_active as 0
             $academicYear->save();
-
+    
             // Get the newly created academic_year_id
             $newAcademicYearId = $academicYear->academic_year_id;
-
-            // Step 2: Insert into academic_year_curricula (for each active curriculum)
-            $activeCurricula = Curriculum::where('status', 'active')->orderBy('curriculum_year', 'asc')->get(); // Fetch active curricula sorted by year
-
-            foreach ($activeCurricula as $curriculum) {
-                $academicYearCurricula = new AcademicYearCurricula();
-                $academicYearCurricula->academic_year_id = $newAcademicYearId;
-                $academicYearCurricula->curriculum_id = $curriculum->curriculum_id;
-                $academicYearCurricula->save();
+    
+            // Step 2: Get the latest active curriculum
+            $latestCurriculum = Curriculum::where('status', 'active')
+                ->orderBy('curriculum_year', 'desc')
+                ->first();
+    
+            if (!$latestCurriculum) {
+                throw new \Exception('No active curriculum found.');
             }
-
-            // Step 3: Insert into active_semesters (3 default semesters with is_active = 0)
+    
+            $latestCurriculumId = $latestCurriculum->curriculum_id;
+    
+            // Step 3: Insert into academic_year_curricula
+            $academicYearCurricula = new AcademicYearCurricula();
+            $academicYearCurricula->academic_year_id = $newAcademicYearId;
+            $academicYearCurricula->curriculum_id = $latestCurriculumId;
+            $academicYearCurricula->save();
+    
+            // Step 4: Insert into active_semesters (3 default semesters with is_active = 0)
             for ($semesterId = 1; $semesterId <= 3; $semesterId++) {
                 $activeSemester = new ActiveSemester();
                 $activeSemester->academic_year_id = $newAcademicYearId;
@@ -460,46 +467,27 @@ class AcademicYearController extends Controller
                 $activeSemester->is_active = 0; // Default value
                 $activeSemester->save();
             }
-
-            // Step 4: Insert into program_year_level_curricula for each active program and year level
-
-            // Fetch all active programs
+    
+            // Step 5: Insert into program_year_level_curricula for each active program and year level
             $activePrograms = Program::where('status', 'active')->get();
-
+    
             foreach ($activePrograms as $program) {
-                // Fetch the number of years dynamically for each program
                 $numberOfYears = $program->number_of_years;
-
-                // Generate year levels based on the number of years for each program
+    
                 for ($yearLevel = 1; $yearLevel <= $numberOfYears; $yearLevel++) {
-                    // Determine the curriculum_id based on year level
-
-                    // Assign the curriculum dynamically based on the current year level and the available curricula
-                    $curriculumId = null;
-                    if ($yearLevel <= $activeCurricula->count()) {
-                        // Assign curriculum in sequence based on the year level
-                        $curriculumId = $activeCurricula[$yearLevel - 1]->curriculum_id;
-                    } else {
-                        // If the year level exceeds the available curricula, use the latest curriculum
-                        $curriculumId = $activeCurricula->last()->curriculum_id;
-                    }
-
-                    // Insert into the program_year_level_curricula table
                     $programYearLevelCurricula = new ProgramYearLevelCurricula();
                     $programYearLevelCurricula->academic_year_id = $newAcademicYearId;
                     $programYearLevelCurricula->program_id = $program->program_id;
                     $programYearLevelCurricula->year_level = $yearLevel;
-                    $programYearLevelCurricula->curriculum_id = $curriculumId;
+                    $programYearLevelCurricula->curriculum_id = $latestCurriculumId;
                     $programYearLevelCurricula->save();
                 }
             }
-
-            // Step 5: Insert into sections_per_program_year for each program and year level
+    
+            // Step 6: Insert into sections_per_program_year for each program and year level
             foreach ($activePrograms as $program) {
-                // Fetch the number of years dynamically for each program
                 $numberOfYears = $program->number_of_years;
-
-                // Generate "Section 1" for all year levels in each program
+    
                 for ($yearLevel = 1; $yearLevel <= $numberOfYears; $yearLevel++) {
                     $section = new SectionsPerProgramYear();
                     $section->academic_year_id = $newAcademicYearId;
@@ -509,25 +497,25 @@ class AcademicYearController extends Controller
                     $section->save();
                 }
             }
-
+    
             // Commit the transaction
             DB::commit();
-
+    
             return response()->json([
                 'message' => 'Academic year added successfully with related data.',
                 'academic_year_id' => $newAcademicYearId
             ], 201);
-
+    
         } catch (\Exception $e) {
             // Rollback the transaction in case of any error
             DB::rollback();
-
+    
             return response()->json([
                 'message' => 'An error occurred: ' . $e->getMessage()
             ], 500);
         }
     }
-
+    
     public function updateYearLevelCurricula(Request $request)
     {
         // Validate the incoming request


### PR DESCRIPTION
This pull request includes significant changes to the `addAcademicYear` method in the `AcademicYearController`. The changes focus on simplifying the process of associating academic years with curricula and programs by using the latest active curriculum instead of iterating through all active curricula.

### Improvements to curriculum association:

* [`backend/app/Http/Controllers/AcademicYearController.php`](diffhunk://#diff-6ff7d85d1353ac24c18efebdafc69f0f4c41592abeaf5d93c1c857d605d517f3L445-R462): Modified the method to fetch only the latest active curriculum and use it for all associations, ensuring consistent and simplified curriculum assignment.
![image](https://github.com/user-attachments/assets/9b50bea2-f7a9-4fec-b293-72aae5d698eb)

### Code simplification and error handling:

* [`backend/app/Http/Controllers/AcademicYearController.php`](diffhunk://#diff-6ff7d85d1353ac24c18efebdafc69f0f4c41592abeaf5d93c1c857d605d517f3L445-R462): Added error handling to throw an exception if no active curriculum is found, enhancing robustness.
* [`backend/app/Http/Controllers/AcademicYearController.php`](diffhunk://#diff-6ff7d85d1353ac24c18efebdafc69f0f4c41592abeaf5d93c1c857d605d517f3L464-L502): Removed unnecessary loops and dynamic curriculum assignment logic, reducing complexity and potential errors.

These changes streamline the method, making the code easier to maintain and less error-prone.