### PR TITLE
Add Start Date on Preferences Submission

### DIFF
--- a/backend/app/Console/Commands/CheckPreferencesDeadline.php
+++ b/backend/app/Console/Commands/CheckPreferencesDeadline.php
@@ -15,6 +15,24 @@ class CheckPreferencesDeadline extends Command
     {
         $today = Carbon::now()->format('Y-m-d');
 
+        // Enable preferences and clear the global start dates
+        PreferencesSetting::query()
+            ->where('is_enabled', false)
+            ->where('global_start_date', '<=', $today)
+            ->update([
+                'is_enabled' => true,
+                'global_start_date' => null,
+            ]);
+
+        // Enable preferences and clear individual start dates
+        PreferencesSetting::query()
+            ->where('is_enabled', false)
+            ->where('individual_start_date', '<=', $today)
+            ->update([
+                'is_enabled' => true,
+                'individual_start_date' => null,
+            ]);
+
         // Disable preferences and clear the global deadlines
         PreferencesSetting::query()
             ->where('is_enabled', true)

--- a/backend/app/Http/Controllers/ReportsController.php
+++ b/backend/app/Http/Controllers/ReportsController.php
@@ -1146,6 +1146,10 @@ class ReportsController extends Controller
             ->whereNotNull('global_deadline')
             ->value('global_deadline');
 
+        $globalStartDate = DB::table('preferences_settings')
+        ->whereNotNull('global_start_date')
+        ->value('global_start_date');
+
         // Step 11: Structure the response with the new field
         return response()->json([
             'activeAcademicYear' => "{$activeSemester->year_start}-{$activeSemester->year_end}",
@@ -1160,6 +1164,7 @@ class ReportsController extends Controller
             'preferencesSubmissionEnabled' => $preferencesSubmissionEnabled,
             'facultyWithSchedulesCount' => $facultyWithSchedulesCount,
             'global_deadline' => $globalDeadline,
+            'global_start_date' => $globalStartDate,
         ]);
     }
 

--- a/backend/app/Models/PreferencesSetting.php
+++ b/backend/app/Models/PreferencesSetting.php
@@ -27,6 +27,8 @@ class PreferencesSetting extends Model
         'is_enabled',
         'global_deadline',
         'individual_deadline',
+        'global_start_date',
+        'individual_start_date',
         'has_request',
     ];
 
@@ -39,6 +41,8 @@ class PreferencesSetting extends Model
         'is_enabled' => 'boolean',
         'global_deadline' => 'date',
         'individual_deadline' => 'date',
+        'global_start_date' => 'date',
+        'individual_start_date' => 'date',
         'has_request' => 'boolean',
     ];
 

--- a/backend/database/migrations/2024_09_30_004059_create_preferences_settings_table.php
+++ b/backend/database/migrations/2024_09_30_004059_create_preferences_settings_table.php
@@ -18,7 +18,9 @@ class CreatePreferencesSettingsTable extends Migration
             $table->unsignedBigInteger('faculty_id')->nullable();
             $table->tinyInteger('has_request')->default(0)->comment('1 for request made, 0 for no request');
             $table->tinyInteger('is_enabled')->default(0)->comment('1 for enabled, 0 for disabled');
+            $table->date('global_start_date')->nullable();
             $table->date('global_deadline')->nullable();
+            $table->date('individual_start_date')->nullable();
             $table->date('individual_deadline')->nullable();
             $table->timestamps();
 

--- a/backend/database/sql/template/pupt_flss_official_v1.sql
+++ b/backend/database/sql/template/pupt_flss_official_v1.sql
@@ -1,9 +1,6 @@
 -- PUPT-FLSS 2025 Official Database Schema (Version 1.7)
 -- Key Changes from the previous version:
--- (+) Add `email` column on `users` table
--- (+) Add separate `*_name` columns on `users` table
--- (-) Remove `faculty_email` column on `faculty` table
-
+-- (+) Add `global_start_date` and `individual_start_date` columns 
 
 -- Table structure for table `users`
 CREATE TABLE `users` (
@@ -210,7 +207,9 @@ CREATE TABLE `preferences_settings` (
   `faculty_id` bigint(20) UNSIGNED DEFAULT NULL,
   `has_request` tinyint(1) NOT NULL DEFAULT '0' COMMENT '1 for request made, 0 for no request',
   `is_enabled` tinyint(1) NOT NULL DEFAULT '0' COMMENT '1 for enabled, 0 for disabled',
+  `global_start_date` date DEFAULT NULL,
   `global_deadline` date DEFAULT NULL,
+  `individual_start_date` date DEFAULT NULL,
   `individual_deadline` date DEFAULT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,

--- a/frontend/src/app/core/components/admin/faculty-pref/faculty-pref.component.html
+++ b/frontend/src/app/core/components/admin/faculty-pref/faculty-pref.component.html
@@ -187,11 +187,17 @@
               <mat-slide-toggle
                 class="header-toggle"
                 [checked]="isToggleAllChecked"
-                [disabled]="hasIndividualDeadlines && !isToggleAllChecked"
+                [disabled]="
+                  (hasIndividualDeadlines &&
+                    !isToggleAllChecked &&
+                    isEnabled) ||
+                  isIndividualStartDateSet
+                "
                 [matTooltip]="getAllToggleTooltip(isToggleAllChecked)"
                 (change)="onToggleAllPreferences($event)"
               >
               </mat-slide-toggle>
+
               <span
                 mat-symbol="help"
                 [fill]="false"
@@ -210,7 +216,7 @@
               <mat-slide-toggle
                 class="single-toggle"
                 [checked]="element.is_enabled"
-                [disabled]="isToggleAllChecked"
+                [disabled]="isToggleAllChecked || isGlobalStartDateSet"
                 [matTooltip]="getSingleToggleTooltip(element)"
                 (change)="onToggleSinglePreferences(element, $event)"
               >

--- a/frontend/src/app/core/components/admin/overview/overview.component.ts
+++ b/frontend/src/app/core/components/admin/overview/overview.component.ts
@@ -47,6 +47,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
     { curriculum_id: 0, curriculum_year: '0' },
   ];
   globalDeadline: string | null = null;
+  globalStartDate: string | null = null;
 
   // Progress metrics
   preferencesProgress = 0;
@@ -130,6 +131,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
     this.preferencesEnabled = data.preferencesSubmissionEnabled;
     this.schedulesPublished = data.publishProgress > 0;
     this.globalDeadline = data.global_deadline || null;
+    this.globalStartDate = data.global_start_date || null;
   }
 
   private resetProgressMetrics(): void {
@@ -160,6 +162,10 @@ export class OverviewComponent implements OnInit, OnDestroy {
       ? new Date(this.globalDeadline)
       : null;
 
+    const StartDate = this.globalStartDate
+    ? new Date(this.globalStartDate)
+    : null;
+
     const dialogData: DialogActionData = {
       type: 'all_preferences',
       academicYear: this.activeYear,
@@ -167,6 +173,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
       hasSecondaryText: true,
       currentState: this.preferencesEnabled,
       global_deadline: deadlineDate,
+      global_start_date: StartDate,
     };
 
     const dialogRef = this.dialog.open(DialogActionComponent, {

--- a/frontend/src/app/core/services/admin/overview/overview.service.ts
+++ b/frontend/src/app/core/services/admin/overview/overview.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { environment } from '../../../../../environments/environment.dev';
 
 export interface OverviewDetails {
+  global_start_date: null;
   activeAcademicYear: string;
   activeSemester: string;
   activeFacultyCount: number;

--- a/frontend/src/app/core/services/faculty/preference/preferences.service.ts
+++ b/frontend/src/app/core/services/faculty/preference/preferences.service.ts
@@ -28,6 +28,8 @@ export interface ActiveSemester {
   courses: Course[];
   global_deadline?: Date | null;
   individual_deadline?: Date | null;
+  global_start_date?: Date | null;
+  individual_start_date?: Date | null;
 }
 
 export interface SemesterDetails {
@@ -227,12 +229,14 @@ export class PreferencesService {
    */
   toggleAllPreferences(
     status: boolean,
-    deadline: string | null
+    deadline: string | null,
+    startDate: string | null
   ): Observable<any> {
     return this.http
       .post(`${this.baseUrl}/toggle-all-preferences`, {
         status,
         global_deadline: deadline,
+        global_start_date: startDate,
       })
       .pipe(
         tap(() => {
@@ -268,13 +272,15 @@ export class PreferencesService {
   toggleSingleFacultyPreferences(
     faculty_id: number,
     status: boolean,
-    individual_deadline: string | null
+    individual_deadline: string | null,
+    individual_start_date: string | null
   ): Observable<any> {
     return this.http
       .post(`${this.baseUrl}/toggle-single-preferences`, {
         faculty_id,
         status,
         individual_deadline,
+        individual_start_date,
       })
       .pipe(
         tap(() => {

--- a/frontend/src/app/shared/dialog-action/dialog-action.component.html
+++ b/frontend/src/app/shared/dialog-action/dialog-action.component.html
@@ -5,7 +5,7 @@
   <!-- Dialog Content -->
   <div class="dialog-content">
     <!-- Main Action Text -->
-    @if (!showReportOptions) {
+    @if (!showReportOptions && !isPreferencesScheduled) {
     <div class="main-text">
       <strong>{{ actionText }}</strong>
 
@@ -45,7 +45,8 @@
     @if (showReportOptions) {
     <div class="main-text">
       This will <strong>print and download</strong> an official copy of the
-      schedule reports for this semester. Select at least one from the following:
+      schedule reports for this semester. Select at least one from the
+      following:
     </div>
 
     <div class="checkbox-container reports">
@@ -75,11 +76,49 @@
     </div>
     }
 
-    <!-- Submission Deadline Date Picker Section -->
-    @if (showDeadlinePicker) {
-    <div class="deadline-picker">
+    <!-- Start Date Picker Section -->
+    @if (showStartDatePicker && !isPreferencesScheduled) {
+    <div class="date-picker">
       <mat-form-field appearance="fill">
-        <mat-label>Submission Deadline</mat-label>
+        <mat-label>Start Date</mat-label>
+        <input
+          matInput
+          [matDatepicker]="startPicker"
+          [min]="currentDate"
+          [(ngModel)]="startDate"
+          (dateChange)="onStartDateChange($event)"
+          [disabled]="data.currentState"
+          readonly
+          required
+        />
+        <mat-datepicker-toggle matIconSuffix [for]="startPicker">
+        </mat-datepicker-toggle>
+        <mat-datepicker #startPicker></mat-datepicker>
+
+        @if (data.type === 'all_preferences' || data.type ===
+        'single_preferences') {
+        <mat-hint>
+          @if (data.currentState) { Current Set Start Date: @if
+          (isStartDateToday) {
+          <strong>{{ getStartDateText(true) }}</strong>
+          } @else {
+          {{ startDate | date }}
+          <strong>({{ remainingDaysStart }} day(s) left)</strong>
+          } } @else { The submission will start @if (isStartDateToday) {
+          <strong>{{ getStartDateText(false) }}</strong>
+          } @else {
+          <strong>{{ remainingDaysStart }} day(s)</strong> from now } }
+        </mat-hint>
+        }
+      </mat-form-field>
+    </div>
+    }
+
+    <!-- Submission Deadline Date Picker Section -->
+    @if (showDeadlinePicker && !isPreferencesScheduled) {
+    <div class="date-picker">
+      <mat-form-field appearance="fill">
+        <mat-label>End Date</mat-label>
         <input
           matInput
           [matDatepicker]="picker"
@@ -102,13 +141,12 @@
           <strong>{{ getDeadlineText(true) }}</strong>
           } @else {
           {{ submissionDeadline | date }}
-          <strong>({{ remainingDays }} days left)</strong>
-          } } @else { The submission will automatically close after @if
-          (isDeadlineToday) {
+          <strong>({{ remainingDays }} day(s) left)</strong>
+          } } @else { The submission will close @if (isDeadlineToday) {
           <strong>{{ getDeadlineText(false) }}</strong>
           } @else {
-          <strong>{{ remainingDays }} days</strong>
-          } }
+          <strong>{{ remainingDays }} day(s)</strong> after the set start date }
+          }
         </mat-hint>
         }
       </mat-form-field>
@@ -116,7 +154,7 @@
     }
 
     <!-- Email Notification Section -->
-    @if (showEmailOption && !data.currentState) {
+    @if (showEmailOption && !data.currentState && !isPreferencesScheduled) {
     <div class="checkbox-container email">
       <mat-checkbox [(ngModel)]="sendEmail" class="email-checkbox">
         <span class="checkbox-content">
@@ -149,19 +187,50 @@
       </div>
     </div>
     }
+
+    <!-- New Section for Scheduled Preferences Submission -->
+    @if (isPreferencesScheduled) {
+    <div class="scheduled-preferences">
+      <div class="scheduled-pref-icon">
+        <span mat-symbol="hourglass_top"></span>
+      </div>
+      <div class="scheduled-pref-text">
+        Preferences submission is currently scheduled to open from
+        <strong>{{ startDate | date }}</strong> until
+        <strong>{{ submissionDeadline | date }}</strong
+        >.
+      </div>
+    </div>
+    }
   </div>
 
   <!-- Dialog Buttons -->
   <div class="dialog-buttons">
     <button
       mat-button
-      class="cancel"
+      class="close"
       (click)="closeDialog()"
       [disabled]="isProcessing"
     >
-      Cancel
+      Close
     </button>
 
+    @if (isPreferencesScheduled) {
+    <button
+      mat-flat-button
+      color="primary"
+      class="action-button"
+      (click)="cancelScheduledSubmission()"
+      [disabled]="isProcessing"
+      [ngClass]="{
+        'disabled-button': isProcessing
+      }"
+    >
+      @if (!isProcessing) { Cancel Scheduled Submission } @else {
+      <mat-spinner class="custom-spinner" diameter="25"></mat-spinner>
+      }
+    </button>
+    } @else {
     <button
       mat-flat-button
       color="primary"
@@ -170,18 +239,21 @@
       [disabled]="
         isProcessing ||
         (data.type === 'reports' && !isReportSelectionValid()) ||
-        (showDeadlinePicker && submissionDeadline === null)
+        (showDeadlinePicker && submissionDeadline === null) ||
+        (showStartDatePicker && startDate === null)
       "
       [ngClass]="{
         'disabled-button':
           isProcessing ||
           (data.type === 'reports' && !isReportSelectionValid()) ||
-          (showDeadlinePicker && submissionDeadline === null)
+          (showDeadlinePicker && submissionDeadline === null) ||
+          (showStartDatePicker && startDate === null)
       }"
     >
       @if (!isProcessing) { Confirm } @else {
       <mat-spinner class="custom-spinner" diameter="25"></mat-spinner>
       }
     </button>
+    }
   </div>
 </div>

--- a/frontend/src/app/shared/dialog-action/dialog-action.component.html
+++ b/frontend/src/app/shared/dialog-action/dialog-action.component.html
@@ -90,6 +90,7 @@
           [disabled]="data.currentState"
           readonly
           required
+          (click)="startPicker.open()"
         />
         <mat-datepicker-toggle matIconSuffix [for]="startPicker">
         </mat-datepicker-toggle>
@@ -121,17 +122,18 @@
         <mat-label>End Date</mat-label>
         <input
           matInput
-          [matDatepicker]="picker"
+          [matDatepicker]="endPicker"
           [min]="minDate"
           [(ngModel)]="submissionDeadline"
           (dateChange)="onDeadlineChange($event)"
           [disabled]="data.currentState"
           readonly
           required
+          (click)="endPicker.open()"
         />
-        <mat-datepicker-toggle matIconSuffix [for]="picker">
+        <mat-datepicker-toggle matIconSuffix [for]="endPicker">
         </mat-datepicker-toggle>
-        <mat-datepicker #picker></mat-datepicker>
+        <mat-datepicker #endPicker></mat-datepicker>
 
         @if (data.type === 'all_preferences' || data.type ===
         'single_preferences') {

--- a/frontend/src/app/shared/dialog-action/dialog-action.component.scss
+++ b/frontend/src/app/shared/dialog-action/dialog-action.component.scss
@@ -137,16 +137,39 @@
     background: var(--neutral-fade) !important;
   }
 
-  .cancel {
+  .close {
     color: var(--primary-text);
   }
 }
 
-.deadline-picker,
+.date-picker,
 .deadline-info {
   width: 100%;
 
   mat-form-field {
     width: 100%;
   }
+}
+
+.set-submission-text {
+  margin-bottom: 0;
+}
+
+.scheduled-preferences {
+  text-align: center;
+}
+
+.scheduled-pref-icon {
+  @include mixins.flex-layout($direction: column, $gap: var(--spacing-xs));
+  margin-bottom: var(--spacing-sm);
+
+  span[mat-symbol] {
+    font-size: var(--font-size-4xl);
+    @include mixins.gradient-primary-text(315deg);
+
+  }
+}
+
+.scheduled-pref-text {
+  line-height: var(--line-height-md);
 }

--- a/frontend/src/app/shared/dialog-action/dialog-action.component.ts
+++ b/frontend/src/app/shared/dialog-action/dialog-action.component.ts
@@ -112,7 +112,6 @@ export class DialogActionComponent {
     programs: false,
     rooms: false,
   };
-
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: DialogActionData,
     private dialogRef: MatDialogRef<DialogActionComponent>,

--- a/frontend/src/app/shared/dialog-action/dialog-action.component.ts
+++ b/frontend/src/app/shared/dialog-action/dialog-action.component.ts
@@ -22,13 +22,20 @@ import { PreferencesService } from '../../core/services/faculty/preference/prefe
 import { ReportsService } from '../../core/services/admin/reports/reports.service';
 
 export interface DialogActionData {
-  type: 'all_preferences' | 'single_preferences' | 'all_publish' | 'single_publish' | 'reports';
+  type:
+    | 'all_preferences'
+    | 'single_preferences'
+    | 'all_publish'
+    | 'single_publish'
+    | 'reports';
   currentState: boolean;
   academicYear?: string;
   semester?: string;
   hasSecondaryText?: boolean;
   global_deadline?: Date | null;
   individual_deadline?: Date | null;
+  global_start_date?: Date | null;
+  individual_start_date?: Date | null;
   facultyName?: string;
   faculty_id?: number;
   hasIndividualDeadlines?: boolean;
@@ -47,29 +54,29 @@ export const MY_DATE_FORMATS = {
 };
 
 @Component({
-    selector: 'app-dialog-action',
-    imports: [
-        RouterLink,
-        MatDialogModule,
-        MatButtonModule,
-        MatCheckboxModule,
-        MatProgressSpinnerModule,
-        FormsModule,
-        CommonModule,
-        MatDatepickerModule,
-        MatNativeDateModule,
-        MatFormFieldModule,
-        MatInputModule,
-        MatSymbolDirective,
-    ],
-    providers: [
-        MatDatepickerModule,
-        { provide: DateAdapter, useClass: NativeDateAdapter },
-        { provide: MAT_DATE_LOCALE, useValue: 'en-US' },
-        { provide: MAT_DATE_FORMATS, useValue: MY_DATE_FORMATS },
-    ],
-    templateUrl: './dialog-action.component.html',
-    styleUrls: ['./dialog-action.component.scss']
+  selector: 'app-dialog-action',
+  imports: [
+    RouterLink,
+    MatDialogModule,
+    MatButtonModule,
+    MatCheckboxModule,
+    MatProgressSpinnerModule,
+    FormsModule,
+    CommonModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSymbolDirective,
+  ],
+  providers: [
+    MatDatepickerModule,
+    { provide: DateAdapter, useClass: NativeDateAdapter },
+    { provide: MAT_DATE_LOCALE, useValue: 'en-US' },
+    { provide: MAT_DATE_FORMATS, useValue: MY_DATE_FORMATS },
+  ],
+  templateUrl: './dialog-action.component.html',
+  styleUrls: ['./dialog-action.component.scss'],
 })
 export class DialogActionComponent {
   private readonly SNACKBAR_DURATION = 5000;
@@ -88,9 +95,17 @@ export class DialogActionComponent {
   showDeadlinePicker = false;
   hasIndividualDeadlines = false;
 
+  currentDate: Date = new Date();
   minDate: Date = new Date();
   submissionDeadline: Date | null = null;
   remainingDays: number = 0;
+
+  startDate: Date | null = null;
+  showStartDatePicker = false;
+  isStartDateToday = false;
+  remainingDaysStart: number = 0;
+
+  isPreferencesScheduled = false;
 
   reportOptions = {
     faculty: false,
@@ -111,20 +126,37 @@ export class DialogActionComponent {
     if (this.data.type === 'all_preferences') {
       this.submissionDeadline = this.data.global_deadline || null;
       this.showDeadlinePicker = true;
-      this.calculateRemainingDays;
+      this.calculateRemainingDays();
+
+      this.startDate = this.data.global_start_date || null;
+      this.showStartDatePicker = true;
+      this.calculateRemainingDaysStart();
     } else if (this.data.type === 'single_preferences') {
       this.submissionDeadline =
         this.data.individual_deadline || this.data.global_deadline || null;
       this.facultyName = this.data.facultyName || '';
       this.showDeadlinePicker = true;
-      this.calculateRemainingDays;
+      this.calculateRemainingDays();
+
+      this.startDate =
+        this.data.individual_start_date || this.data.global_start_date || null;
+      this.showStartDatePicker = true;
+      this.calculateRemainingDaysStart();
     }
 
     if (this.submissionDeadline) {
       this.calculateRemainingDays();
     }
 
+    if (this.startDate) {
+      this.calculateRemainingDaysStart();
+    }
+
     this.hasIndividualDeadlines = this.data.hasIndividualDeadlines || false;
+
+    this.isPreferencesScheduled =
+      Boolean(this.data.global_start_date || this.data.individual_start_date) &&
+      !this.data.currentState;
   }
 
   /**
@@ -189,6 +221,21 @@ export class DialogActionComponent {
       return;
     }
 
+    // Check if both startDate and submissionDeadline are filled out
+    if (this.showStartDatePicker && !this.startDate) {
+      this.snackBar.open('Please select a start date.', 'Close', {
+        duration: this.SNACKBAR_DURATION,
+      });
+      return;
+    }
+
+    if (this.showDeadlinePicker && !this.submissionDeadline) {
+      this.snackBar.open('Please select a submission deadline.', 'Close', {
+        duration: this.SNACKBAR_DURATION,
+      });
+      return;
+    }
+
     this.isProcessing = true;
     let operation$: Observable<any>;
 
@@ -244,22 +291,80 @@ export class DialogActionComponent {
   }
 
   /**
+   * Calculates remaining days between today and start date
+   * and determines if the start date is today
+   */
+  public calculateRemainingDaysStart(): void {
+    if (this.startDate) {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      const startDate = new Date(this.startDate);
+      startDate.setHours(0, 0, 0, 0);
+
+      const diffTime = startDate.getTime() - today.getTime();
+      this.remainingDaysStart = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+      this.isStartDateToday =
+        this.remainingDaysStart <= 0 && this.remainingDaysStart >= -1;
+    }
+  }
+
+  /**
+   * Returns formatted start date text based on whether start date is today
+   */
+  public getStartDateText(isCurrentStartDate: boolean = false): string {
+    if (!this.startDate) return '';
+
+    if (this.isStartDateToday) {
+      if (isCurrentStartDate) {
+        return 'Today';
+      } else {
+        return 'today, immediately';
+      }
+    }
+
+    if (isCurrentStartDate) {
+      return `${formatDate(this.startDate, 'longDate', 'en-US')} (${
+        this.remainingDaysStart
+      } days left)`;
+    } else {
+      return `${this.remainingDaysStart} day(s)`;
+    }
+  }
+
+  /**
+   * Handles start date change
+   */
+  public onStartDateChange(event: any): void {
+    this.startDate = event.value;
+    this.calculateRemainingDaysStart();
+    this.minDate = this.startDate!;
+
+    if (this.submissionDeadline && this.startDate! > this.submissionDeadline!) {
+      this.submissionDeadline = null;
+      this.calculateRemainingDays();
+    } else {
+      this.calculateRemainingDays();
+    }
+  }
+
+  /**
    * Calculates remaining days between today and submission deadline
    * and determines if the deadline is today
    */
   public calculateRemainingDays(): void {
-    if (this.submissionDeadline) {
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
+    if (this.submissionDeadline && this.startDate) {
+      const startDate = new Date(this.startDate);
+      startDate.setHours(0, 0, 0, 0);
 
       const deadline = new Date(this.submissionDeadline);
       deadline.setHours(0, 0, 0, 0);
 
-      const diffTime = deadline.getTime() - today.getTime();
+      const diffTime = deadline.getTime() - startDate.getTime();
       this.remainingDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
 
-      this.isDeadlineToday =
-        this.remainingDays <= 0 && this.remainingDays >= -1;
+      this.isDeadlineToday = this.remainingDays === 0;
     }
   }
 
@@ -269,7 +374,15 @@ export class DialogActionComponent {
   public getDeadlineText(isCurrentDeadline: boolean = false): string {
     if (!this.submissionDeadline) return '';
 
-    if (this.isDeadlineToday) {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const deadline = new Date(this.submissionDeadline);
+    deadline.setHours(0, 0, 0, 0);
+
+    const isActuallyToday = today.getTime() === deadline.getTime();
+
+    if (isActuallyToday) {
       if (isCurrentDeadline) {
         return 'Today at 11:59 PM';
       } else {
@@ -280,9 +393,10 @@ export class DialogActionComponent {
     if (isCurrentDeadline) {
       return `${formatDate(this.submissionDeadline, 'longDate', 'en-US')} (${
         this.remainingDays
-      } days left)`;
+      } day(s) left)`;
     } else {
-      return `${this.remainingDays} days`;
+      // return `${this.remainingDays} day(s)`;
+      return `at 11:59 PM on this day`;
     }
   }
 
@@ -295,24 +409,99 @@ export class DialogActionComponent {
   }
 
   /**
+   * Returns the formatted scheduled start date
+   */
+  public getScheduledStartDate(): string {
+    const startDate =
+      this.data.individual_start_date || this.data.global_start_date;
+    return startDate ? formatDate(startDate, 'medium', 'en-US') : '';
+  }
+
+  /**
+   * Returns the formatted scheduled deadline date
+   */
+  public getScheduledDeadlineDate(): string {
+    const deadline = this.data.individual_deadline || this.data.global_deadline;
+    return deadline ? formatDate(deadline, 'medium', 'en-US') : '';
+  }
+
+  /**
+   * Placeholder method for canceling scheduled submission
+   * This will be implemented later as per your requirement
+   */
+  public cancelScheduledSubmission(): void {
+    this.isProcessing = true;
+
+    let operation$: Observable<any>;
+
+    if (this.data.type === 'all_preferences') {
+      operation$ = this.preferencesService.toggleAllPreferences(
+        false,
+        null,
+        null
+      );
+    } else if (this.data.type === 'single_preferences') {
+      operation$ = this.preferencesService.toggleSingleFacultyPreferences(
+        this.data.faculty_id!,
+        false,
+        null,
+        null
+      );
+    } else {
+      operation$ = of(null);
+    }
+
+    operation$
+      .pipe(
+        finalize(() => {
+          this.isProcessing = false;
+        })
+      )
+      .subscribe({
+        next: () => {
+          const successMessage = 'Scheduled submission canceled successfully.';
+          this.snackBar.open(successMessage, 'Close', {
+            duration: this.SNACKBAR_DURATION,
+          });
+          this.dialogRef.close(true);
+        },
+        error: (error) => {
+          console.error('Operation failed:', error);
+          const errorMessage = 'Failed to cancel scheduled submission.';
+          this.snackBar.open(errorMessage, 'Close', {
+            duration: this.SNACKBAR_DURATION,
+          });
+          this.dialogRef.close(false);
+        },
+      });
+  }
+
+  /**
    * Handles the single preference toggle operation
    */
   private handleSinglePreferenceOperation(): Observable<any> {
     const newStatus = !this.data.currentState;
+
+    let formattedStartDate: string | null = null;
+    if (newStatus && this.startDate) {
+      const date = new Date(this.startDate);
+      date.setHours(0, 0, 0, 0);
+      formattedStartDate = formatDate(date, 'yyyy-MM-dd HH:mm:ss', 'en-US');
+    }
 
     let formattedDate: string | null = null;
     if (newStatus && this.submissionDeadline) {
       const date = new Date(this.submissionDeadline);
       date.setHours(23, 59, 59, 999);
       formattedDate = formatDate(date, 'yyyy-MM-dd HH:mm:ss', 'en-US');
-      console.log('Sending individual deadline to backend:', formattedDate);
     }
 
     return this.preferencesService
       .toggleSingleFacultyPreferences(
         this.data.faculty_id!,
         newStatus,
-        formattedDate
+        formattedDate,
+        formattedStartDate
       )
       .pipe(
         switchMap(() => {
@@ -340,6 +529,13 @@ export class DialogActionComponent {
   private handleAllPreferencesOperation(): Observable<any> {
     const newStatus = !this.data.currentState;
 
+    let formattedStartDate: string | null = null;
+    if (newStatus && this.startDate) {
+      const date = new Date(this.startDate);
+      date.setHours(0, 0, 0, 0);
+      formattedStartDate = formatDate(date, 'yyyy-MM-dd HH:mm:ss', 'en-US');
+    }
+
     let formattedDate: string | null = null;
     if (newStatus && this.submissionDeadline) {
       const date = new Date(this.submissionDeadline);
@@ -349,7 +545,8 @@ export class DialogActionComponent {
 
     const togglePreferences$ = this.preferencesService.toggleAllPreferences(
       newStatus,
-      formattedDate
+      formattedDate,
+      formattedStartDate
     );
 
     const emailNotification$ =
@@ -493,8 +690,8 @@ export class DialogActionComponent {
       case 'reports':
         return 'Reports generated successfully.';
       case 'all_preferences':
-        return `Preferences for all faculty ${
-          !this.data.currentState ? 'enabled' : 'disabled'
+        return `Preferences submission for all faculty ${
+          !this.data.currentState ? 'updated' : 'disabled'
         } successfully.${this.sendEmail ? ' Email sent.' : ''}`;
       case 'all_publish':
         return `Schedules for all faculty ${
@@ -505,8 +702,8 @@ export class DialogActionComponent {
           !this.data.currentState ? 'published' : 'unpublished'
         } successfully.${this.sendEmail ? ' Email sent.' : ''}`;
       case 'single_preferences':
-        return `Preferences for ${this.facultyName} ${
-          !this.data.currentState ? 'enabled' : 'disabled'
+        return `Preferences submission for ${this.facultyName} ${
+          !this.data.currentState ? 'updated' : 'disabled'
         } successfully.${this.sendEmail ? ' Email sent.' : ''}`;
       default:
         return 'Operation completed successfully.';


### PR DESCRIPTION
As per our panel's recommendation, I added start date configuration when enabling preferences submission, both for all and individual faculty. This also includes proper validation and adjusting the scheduled job to automatically enable/disable the submission based on start + end date period.

![image](https://github.com/user-attachments/assets/09a57cdd-7ba9-4d97-be26-c08d94a6ca1c)

