### PR TITLE
Refactor preferences process to allow multi-day/time association to a course

### DIFF
--- a/backend/app/Console/Commands/AddApiKey.php
+++ b/backend/app/Console/Commands/AddApiKey.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\ApiKey;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Crypt;
+
+class AddApiKey extends Command
+{
+    protected $signature = 'api:add-key {system} {key?} {--active} {--inactive}';
+    protected $description = 'Add an API key to the database or update an existing one';
+
+    public function handle()
+    {
+        if (!$this->validateInput()) {
+            return 1;
+        }
+
+        $system = $this->argument('system');
+        $key = $this->argument('key');
+        $active = $this->option('active');
+        $inactive = $this->option('inactive');
+
+        try {
+            DB::beginTransaction();
+
+            if (empty($key)) {
+                $this->info("No API key provided. Nothing to add or update.");
+                DB::commit();
+                return 0;
+            }
+
+            // Find existing key by decrypting and comparing
+            $existingKey = $this->findExistingKey($system, $key);
+
+            if ($existingKey) {
+                if ($active || $inactive) {
+                    $this->updateKeyStatus($system, $existingKey, $active);
+                    $this->info("API key status updated successfully.");
+                } else {
+                    $this->error("This exact API key already exists for the system '{$system}'.");
+                    DB::rollBack();
+                    return 1;
+                }
+            } else {
+                // Add new key (always inactive by default unless --active is specified)
+                $this->addNewKey($system, $key, $active);
+                $this->info("New API key added successfully for system '{$system}'.");
+            }
+
+            DB::commit();
+            return 0;
+        } catch (\Exception $e) {
+            DB::rollBack();
+            $this->error('Error: ' . $e->getMessage());
+            return 1;
+        }
+    }
+
+    private function validateInput(): bool
+    {
+        $key = $this->argument('key');
+        $active = $this->option('active');
+        $inactive = $this->option('inactive');
+
+        if ($active && $inactive) {
+            $this->error('Cannot use --active and --inactive options at the same time.');
+            return false;
+        }
+
+        if (empty($key) && ($active || $inactive)) {
+            $this->error('The --active or --inactive options can only be used when providing an API key.');
+            return false;
+        }
+
+        if (!empty($key)) {
+            $validator = Validator::make(
+                [
+                    'system' => $this->argument('system'),
+                    'key' => $key,
+                ],
+                [
+                    'system' => 'required|string',
+                    'key' => ['required', 'string', 'min:64'],
+                ]
+            );
+
+            if ($validator->fails()) {
+                $this->error('Invalid input:');
+                foreach ($validator->errors()->all() as $error) {
+                    $this->error($error);
+                }
+                $this->info("\nTip: You can generate a secure API key using the command:");
+                $this->info("php artisan api:generate-key");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function findExistingKey(string $system, string $key): ?ApiKey
+    {
+        $keys = ApiKey::where('system', $system)->get();
+        
+        foreach ($keys as $existingKey) {
+            try {
+                $decryptedKey = Crypt::decryptString($existingKey->encrypted_key);
+                if ($decryptedKey === $key) {
+                    return $existingKey;
+                }
+            } catch (\Exception $e) {
+                continue;
+            }
+        }
+        
+        return null;
+    }
+
+    private function updateKeyStatus(string $system, ApiKey $apiKey, bool $setActive): void
+    {
+        if ($setActive) {
+            // First, set all keys for this system as inactive
+            ApiKey::where('system', $system)->update(['is_active' => false]);
+        }
+
+        // Update the status of the specific key
+        $apiKey->is_active = $setActive;
+        $apiKey->save();
+    }
+
+    private function addNewKey(string $system, string $key, bool $setActive): void
+    {
+        if ($setActive) {
+            // If adding a new active key, set all existing keys to inactive
+            ApiKey::where('system', $system)->update(['is_active' => false]);
+        }
+
+        // Add the new key (inactive by default unless --active is specified)
+        ApiKey::create([
+            'system' => $system,
+            'key' => $key,
+            'is_active' => $setActive,
+        ]);
+    }
+}

--- a/backend/app/Console/Commands/GenerateApiKey.php
+++ b/backend/app/Console/Commands/GenerateApiKey.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class GenerateApiKey extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'api:generate-key {--length=64}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate a random API key';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $length = $this->option('length');
+
+        if (!is_numeric($length) || $length <= 0) {
+            $this->error('Invalid length. Length must be a positive integer.');
+            return 1;
+        }
+
+        // Generate the random key
+        $key = Str::random($length);
+
+        $this->info("Generated API key ({$length} characters):");
+        $this->line($key);
+
+        return 0;
+    }
+}

--- a/backend/app/Console/Commands/GetApiKeys.php
+++ b/backend/app/Console/Commands/GetApiKeys.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\ApiKey;
+use Illuminate\Console\Command;
+
+class GetApiKeys extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'api:get-keys {system}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Get API keys for a system';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $system = $this->argument('system');
+
+        // Get all API keys for the system, ordered by active first
+        $apiKeys = ApiKey::where('system', $system)
+            ->orderBy('is_active', 'desc')
+            ->get();
+
+        if ($apiKeys->isEmpty()) {
+            $this->info("No API keys found for system '{$system}'.");
+            return 0;
+        }
+
+        $this->info("API keys for system '{$system}':");
+
+        $headers = ['Key', 'Status', 'Created At', 'Updated At'];
+        $rows = $apiKeys->map(function ($apiKey) {
+            return [
+                $apiKey->key,
+                $apiKey->is_active ? 'Active' : 'Inactive',
+                $apiKey->created_at,
+                $apiKey->updated_at,
+            ];
+        });
+
+        $this->table($headers, $rows);
+
+        return 0;
+    }
+}

--- a/backend/app/Http/Controllers/External/v1/ExternalController.php
+++ b/backend/app/Http/Controllers/External/v1/ExternalController.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\External\V1;
 
+use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 

--- a/backend/app/Http/Controllers/ExternalController.php
+++ b/backend/app/Http/Controllers/ExternalController.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class ExternalController extends Controller
+{
+    public function ECRSFacultySchedules()
+    {
+        // Step 1: Retrieve the current active semester with academic year details
+        $activeSemester = DB::table('active_semesters')
+            ->join('academic_years', 'active_semesters.academic_year_id', '=', 'academic_years.academic_year_id')
+            ->join('semesters', 'active_semesters.semester_id', '=', 'semesters.semester_id')
+            ->where('active_semesters.is_active', 1)
+            ->select(
+                'academic_years.year_start',
+                'academic_years.year_end',
+                'semesters.semester',
+                'active_semesters.academic_year_id',
+                'active_semesters.active_semester_id'
+            )
+            ->first();
+
+        if (!$activeSemester) {
+            return response()->json(['message' => 'No active semester found.'], 404);
+        }
+
+        // Step 2: Prepare a subquery to get schedules for the current semester and academic year
+        $schedulesSub = DB::table('schedules')
+            ->join('section_courses', 'schedules.section_course_id', '=', 'section_courses.section_course_id')
+            ->join('course_assignments', 'course_assignments.course_assignment_id', '=', 'section_courses.course_assignment_id')
+            ->join('semesters as ca_semesters', 'ca_semesters.semester_id', '=', 'course_assignments.semester_id')
+            ->join('sections_per_program_year', 'sections_per_program_year.sections_per_program_year_id', '=', 'section_courses.sections_per_program_year_id')
+            ->where('ca_semesters.semester', '=', $activeSemester->semester)
+            ->where('sections_per_program_year.academic_year_id', '=', $activeSemester->academic_year_id)
+            ->select(
+                'schedules.schedule_id',
+                'schedules.faculty_id',
+                'schedules.day',
+                'schedules.start_time',
+                'schedules.end_time',
+                'schedules.room_id',
+                'schedules.section_course_id'
+            );
+
+        // Step 3: Join faculties with current schedules
+        $facultySchedules = DB::table('faculty')
+            ->join('users', 'faculty.user_id', '=', 'users.id')
+            ->leftJoinSub($schedulesSub, 'current_schedules', function ($join) {
+                $join->on('current_schedules.faculty_id', '=', 'faculty.id');
+            })
+            ->leftJoin('section_courses', 'current_schedules.section_course_id', '=', 'section_courses.section_course_id')
+            ->leftJoin('sections_per_program_year', 'sections_per_program_year.sections_per_program_year_id', '=', 'section_courses.sections_per_program_year_id')
+            ->leftJoin('programs', 'programs.program_id', '=', 'sections_per_program_year.program_id')
+            ->leftJoin('course_assignments', 'course_assignments.course_assignment_id', '=', 'section_courses.course_assignment_id')
+            ->leftJoin('courses', 'courses.course_id', '=', 'course_assignments.course_id')
+            ->leftJoin('rooms', 'rooms.room_id', '=', 'current_schedules.room_id')
+            ->leftJoin('faculty_schedule_publication', function ($join) {
+                $join->on('faculty_schedule_publication.schedule_id', '=', 'current_schedules.schedule_id')
+                    ->on('faculty_schedule_publication.faculty_id', '=', 'faculty.id');
+            })
+            ->select(
+                'faculty.id as faculty_id',
+                'users.id as user_id',
+                'users.code as faculty_code',
+                'faculty.faculty_type',
+                'current_schedules.schedule_id',
+                'current_schedules.day',
+                'current_schedules.start_time',
+                'current_schedules.end_time',
+                'rooms.room_code',
+                'course_assignments.course_assignment_id',
+                'courses.course_title',
+                'courses.course_code',
+                'courses.lec_hours',
+                'courses.lab_hours',
+                'courses.units',
+                'courses.tuition_hours',
+                'programs.program_code',
+                'programs.program_title',
+                'sections_per_program_year.year_level',
+                'sections_per_program_year.section_name',
+                DB::raw('IFNULL(faculty_schedule_publication.is_published, 0) as is_published')
+            )
+            ->get();
+
+        // Step 3.1: Collect unique user_ids to fetch User models
+        $userIds = $facultySchedules->pluck('user_id')->unique()->toArray();
+
+        // Step 3.2: Fetch User models
+        $users = User::whereIn('id', $userIds)->get()->keyBy('id');
+
+        // Step 4: Group the data by faculty and structure schedules
+        $faculties = [];
+
+        foreach ($facultySchedules as $schedule) {
+            if (!isset($faculties[$schedule->faculty_id])) {
+                $faculties[$schedule->faculty_id] = [
+                    'faculty_id' => $schedule->faculty_id,
+                    'last_name' => $users[$schedule->user_id]->last_name ?? null,
+                    'first_name' => $users[$schedule->user_id]->first_name ?? null,
+                    'middle_name' => $users[$schedule->user_id]->middle_name ?? null,
+                    'suffix_name' => $users[$schedule->user_id]->suffix_name ?? null,
+                    'faculty_code' => $schedule->faculty_code,
+                    'faculty_type' => $schedule->faculty_type,
+                    'assigned_units' => 0,
+                    'schedules' => [],
+                    'tracked_courses' => [],
+                ];
+            }
+
+            if ($schedule->schedule_id) {
+                // Only add units if we haven't counted this course assignment before
+                if (!in_array($schedule->course_assignment_id, $faculties[$schedule->faculty_id]['tracked_courses'])) {
+                    $faculties[$schedule->faculty_id]['assigned_units'] += $schedule->units;
+                    $faculties[$schedule->faculty_id]['tracked_courses'][] = $schedule->course_assignment_id;
+                }
+
+                $faculties[$schedule->faculty_id]['schedules'][] = [
+                    'day' => $schedule->day,
+                    'start_time' => $schedule->start_time,
+                    'end_time' => $schedule->end_time,
+                    'room_code' => $schedule->room_code,
+                    'program_code' => $schedule->program_code,
+                    'program_title' => $schedule->program_title,
+                    'year_level' => $schedule->year_level,
+                    'section_name' => $schedule->section_name,
+                    'course_details' => [
+                        'course_assignment_id' => $schedule->course_assignment_id,
+                        'course_title' => $schedule->course_title,
+                        'course_code' => $schedule->course_code,
+                        'lec' => $schedule->lec_hours,
+                        'lab' => $schedule->lab_hours,
+                        'units' => $schedule->units,
+                        'tuition_hours' => $schedule->tuition_hours,
+                    ],
+                ];
+            }
+        }
+
+        // Remove the tracking array before sending response
+        foreach ($faculties as &$faculty) {
+            unset($faculty['tracked_courses']);
+        }
+
+        // Step 4.1: Sort the faculties by faculty_name
+        // $faculties = collect($faculties)->sortBy('faculty_name')->values()->all();
+
+        // Step 5: Structure the response
+        return response()->json([
+            'pupt_faculty_schedules' => [
+                'academic_year_start' => $activeSemester->year_start,
+                'academic_year_end' => $activeSemester->year_end,
+                'semester' => $activeSemester->semester,
+                'faculties' => array_values($faculties),
+            ],
+        ]);
+    }
+}

--- a/backend/app/Http/Controllers/ReportsController.php
+++ b/backend/app/Http/Controllers/ReportsController.php
@@ -1146,6 +1146,10 @@ class ReportsController extends Controller
             ->whereNotNull('global_deadline')
             ->value('global_deadline');
 
+        $globalStartDate = DB::table('preferences_settings')
+        ->whereNotNull('global_start_date')
+        ->value('global_start_date');
+
         // Step 11: Structure the response with the new field
         return response()->json([
             'activeAcademicYear' => "{$activeSemester->year_start}-{$activeSemester->year_end}",
@@ -1160,6 +1164,7 @@ class ReportsController extends Controller
             'preferencesSubmissionEnabled' => $preferencesSubmissionEnabled,
             'facultyWithSchedulesCount' => $facultyWithSchedulesCount,
             'global_deadline' => $globalDeadline,
+            'global_start_date' => $globalStartDate,
         ]);
     }
 

--- a/backend/app/Http/Kernel.php
+++ b/backend/app/Http/Kernel.php
@@ -71,5 +71,6 @@ class Kernel extends HttpKernel
         'super_admin' => \App\Http\Middleware\SuperAdminMiddleware::class,
         'encrypt.response' => \App\Http\Middleware\EncryptJsonResponse::class,
         'check.api.key' => \App\Http\Middleware\CheckApiKey::class,
+        'check.hmac' => \App\Http\Middleware\CheckHmac::class,
     ];
 }

--- a/backend/app/Http/Kernel.php
+++ b/backend/app/Http/Kernel.php
@@ -68,6 +68,8 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
-         'super_admin' => \App\Http\Middleware\SuperAdminMiddleware::class,
+        'super_admin' => \App\Http\Middleware\SuperAdminMiddleware::class,
+        'encrypt.response' => \App\Http\Middleware\EncryptJsonResponse::class,
+        'check.api.key' => \App\Http\Middleware\CheckApiKey::class,
     ];
 }

--- a/backend/app/Http/Middleware/CheckApiKey.php
+++ b/backend/app/Http/Middleware/CheckApiKey.php
@@ -4,27 +4,88 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\Response;
 
 class CheckApiKey
 {
     /**
-     * Handle an incoming request.
+     * Validates API key from X-API-Key header against environment configuration.
+     * Requires {SYSTEM}_API_KEY to be set in environment variables.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
-     * @param  string  $system
-     * @return \Illuminate\Http\Response|mixed
+     * @param  Request  $request
+     * @param  Closure  $next
+     * @param  string  $system System identifier for API key configuration
+     * @return Response|mixed
      */
     public function handle(Request $request, Closure $next, string $system)
     {
-        $apiKey = $request->header('X-API-Key');
-        $expectedApiKey = env(strtoupper($system) . '_API_KEY');
+        try {
+            // Sanitize and validate system parameter
+            $system = trim($system);
+            if (empty($system)) {
+                Log::error('API Key middleware: Empty system parameter provided');
+                return $this->errorResponse('Invalid system configuration', 500);
+            }
 
-        if ($apiKey !== $expectedApiKey) {
-            return response()->json(['message' => 'Unauthorized'], 403);
+            // Get and validate API key from header
+            $apiKey = $request->header('X-API-Key');
+            if (empty($apiKey)) {
+                Log::warning('API Key middleware: Missing API key header', [
+                    'ip' => $request->ip(),
+                    'path' => $request->path(),
+                    'system' => $system,
+                ]);
+                return $this->errorResponse('API key is required', 401);
+            }
+
+            // Get expected API key from environment
+            $envKey = strtoupper($system) . '_API_KEY';
+            $expectedApiKey = config($envKey) ?? env($envKey);
+
+            // Check if API key is configured
+            if (empty($expectedApiKey)) {
+                Log::error('API Key middleware: Missing environment configuration', [
+                    'system' => $system,
+                    'env_key' => $envKey,
+                ]);
+                return $this->errorResponse('API key configuration error', 500);
+            }
+
+            // Validate API key
+            if (!hash_equals($expectedApiKey, $apiKey)) {
+                Log::warning('API Key middleware: Invalid API key used', [
+                    'ip' => $request->ip(),
+                    'path' => $request->path(),
+                    'system' => $system,
+                ]);
+                return $this->errorResponse('Invalid API key', 403);
+            }
+
+            return $next($request);
+
+        } catch (\Exception $e) {
+            Log::error('API Key middleware: Unexpected error', [
+                'error' => $e->getMessage(),
+                'system' => $system ?? 'unknown',
+                'path' => $request->path(),
+            ]);
+            return $this->errorResponse('Internal server error', 500);
         }
+    }
 
-        return $next($request);
+    /**
+     * Returns a standardized JSON error response
+     *
+     * @param string $message
+     * @param int $status
+     * @return Response
+     */
+    private function errorResponse(string $message, int $status): Response
+    {
+        return response()->json([
+            'error' => true,
+            'message' => $message,
+        ], $status);
     }
 }

--- a/backend/app/Http/Middleware/CheckApiKey.php
+++ b/backend/app/Http/Middleware/CheckApiKey.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckApiKey
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string  $system
+     * @return \Illuminate\Http\Response|mixed
+     */
+    public function handle(Request $request, Closure $next, string $system)
+    {
+        $apiKey = $request->header('X-API-Key');
+        $expectedApiKey = env(strtoupper($system) . '_API_KEY');
+
+        if ($apiKey !== $expectedApiKey) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/backend/app/Http/Middleware/CheckHmac.php
+++ b/backend/app/Http/Middleware/CheckHmac.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\ApiKey;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckHmac
+{
+    /**
+     * Constants for HMAC configuration
+     */
+    private const TIMESTAMP_WINDOW = 300;
+    private const HASH_ALGORITHM = 'sha256';
+    private const NONCE_CACHE_PREFIX = 'hmac_nonce:';
+    private const NONCE_EXPIRY_MINUTES = 5;
+
+    /**
+     * Validates HMAC signature from headers against database configuration and request data.
+     *
+     * @param  Request  $request
+     * @param  Closure  $next
+     * @param  string  $system System identifier for API key configuration
+     * @return Response|mixed
+     */
+    public function handle(Request $request, Closure $next, string $system)
+    {
+        try {
+            // Validate system parameter
+            if (!$this->validateSystem($system)) {
+                return $this->errorResponse('Invalid system configuration', 500);
+            }
+
+            // Get API key configuration
+            $apiKeyRecord = $this->getApiKeyRecord($system);
+            if (!$apiKeyRecord) {
+                return $this->errorResponse('API key configuration error', 500);
+            }
+
+            // Validate request headers
+            $validationResponse = $this->validateRequestHeaders($request);
+            if ($validationResponse) {
+                return $validationResponse;
+            }
+
+            // Get headers
+            $signature = $request->header('X-HMAC-Signature');
+            $timestamp = $request->header('X-HMAC-Timestamp');
+            $nonce = $request->header('X-HMAC-Nonce');
+
+            // Validate timestamp
+            if (!$this->isTimestampValid($timestamp)) {
+                return $this->errorResponse('HMAC timestamp expired', 401);
+            }
+
+            // Validate nonce if provided
+            if ($nonce) {
+                $nonceValidation = $this->validateNonce($nonce);
+                if ($nonceValidation) {
+                    return $nonceValidation;
+                }
+            }
+
+            // Validate HMAC signature
+            if (!$this->isSignatureValid($request, $signature, $timestamp, $nonce, $apiKeyRecord->key)) {
+                return $this->errorResponse('Invalid HMAC signature', 403);
+            }
+
+            return $next($request);
+
+        } catch (\Exception $e) {
+            Log::error('HMAC middleware: Unexpected error', [
+                'error' => $e->getMessage(),
+                'system' => $system ?? 'unknown',
+                'path' => $request->path(),
+            ]);
+            return $this->errorResponse('Internal server error', 500);
+        }
+    }
+
+    /**
+     * Validates the system parameter
+     */
+    private function validateSystem(string $system): bool
+    {
+        return !empty(trim($system));
+    }
+
+    /**
+     * Gets the API key record from database
+     */
+    private function getApiKeyRecord(string $system)
+    {
+        return ApiKey::where('system', $system)
+            ->where('is_active', true)
+            ->first();
+    }
+
+    /**
+     * Validates required request headers
+     */
+    private function validateRequestHeaders(Request $request): ?Response
+    {
+        $signature = $request->header('X-HMAC-Signature');
+        $timestamp = $request->header('X-HMAC-Timestamp');
+
+        if (empty($signature) || empty($timestamp)) {
+            Log::warning('HMAC middleware: Missing HMAC headers', [
+                'ip' => $request->ip(),
+                'path' => $request->path(),
+            ]);
+            return $this->errorResponse('HMAC signature and timestamp are required', 401);
+        }
+
+        return null;
+    }
+
+    /**
+     * Validates if timestamp is within acceptable window
+     */
+    private function isTimestampValid(int $timestamp): bool
+    {
+        return abs(time() - $timestamp) <= self::TIMESTAMP_WINDOW;
+    }
+
+    /**
+     * Validates nonce to prevent replay attacks
+     */
+    private function validateNonce(string $nonce): ?Response
+    {
+        $nonceKey = self::NONCE_CACHE_PREFIX . $nonce;
+
+        if (Cache::has($nonceKey)) {
+            Log::warning('HMAC middleware: Nonce reuse attempt', [
+                'nonce' => $nonce,
+            ]);
+            return $this->errorResponse('Nonce already used', 401);
+        }
+
+        Cache::put($nonceKey, true, now()->addMinutes(self::NONCE_EXPIRY_MINUTES));
+        return null;
+    }
+
+    /**
+     * Validates HMAC signature
+     */
+    private function isSignatureValid(Request $request, string $signature, int $timestamp, ?string $nonce, string $key): bool
+    {
+        $message = $this->constructMessage($request, $timestamp, $nonce);
+        $expectedSignature = hash_hmac(self::HASH_ALGORITHM, $message, $key);
+
+        return hash_equals($expectedSignature, $signature);
+    }
+
+    /**
+     * Constructs the message for HMAC signing
+     */
+    private function constructMessage(Request $request, int $timestamp, ?string $nonce): string
+    {
+        return implode('|', [
+            $request->method(),
+            $request->fullUrl(),
+            $request->getContent(),
+            $timestamp,
+            $nonce ?? '',
+        ]);
+    }
+
+    /**
+     * Returns a standardized JSON error response
+     */
+    private function errorResponse(string $message, int $status): Response
+    {
+        return response()->json([
+            'error' => true,
+            'message' => $message,
+        ], $status);
+    }
+}

--- a/backend/app/Http/Middleware/EncryptJsonResponse.php
+++ b/backend/app/Http/Middleware/EncryptJsonResponse.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Crypt;
+
+class EncryptJsonResponse
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+
+        // Only encrypt successful JSON responses
+        if ($response instanceof JsonResponse
+            && $response->getStatusCode() >= 200
+            && $response->getStatusCode() < 300) {
+            $data = $response->getData(true);
+
+            $encryptedData = Crypt::encryptString(json_encode($data));
+
+            $response->setContent(json_encode(['encrypted' => $encryptedData]));
+        }
+
+        return $response;
+    }
+}

--- a/backend/app/Http/Middleware/EncryptJsonResponse.php
+++ b/backend/app/Http/Middleware/EncryptJsonResponse.php
@@ -1,16 +1,19 @@
 <?php
-
 namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Log;
+use JsonException;
+use Illuminate\Encryption\EncryptException;
 
 class EncryptJsonResponse
 {
     /**
-     * Handle an incoming request.
-     *
+     * Encrypts successful JSON responses (200-299) before sending to client.
+     * Wraps encrypted data in {'encrypted': 'encryptedString'} format.
+     * 
      * @param \Illuminate\Http\Request $request
      * @param \Closure $next
      * @return mixed
@@ -19,15 +22,67 @@ class EncryptJsonResponse
     {
         $response = $next($request);
 
-        // Only encrypt successful JSON responses
-        if ($response instanceof JsonResponse
-            && $response->getStatusCode() >= 200
-            && $response->getStatusCode() < 300) {
+        // Skip encryption for non-JSON responses or non-successful status codes
+        if (!($response instanceof JsonResponse) || 
+            $response->getStatusCode() < 200 || 
+            $response->getStatusCode() >= 300) {
+            return $response;
+        }
+
+        try {
+            // Extract response data and prepare for encryption
             $data = $response->getData(true);
+            
+            // Convert data to JSON string with strict error checking
+            $jsonData = json_encode($data, JSON_THROW_ON_ERROR);
+            if ($jsonData === false) {
+                throw new JsonException('Failed to encode response data');
+            }
 
-            $encryptedData = Crypt::encryptString(json_encode($data));
-
-            $response->setContent(json_encode(['encrypted' => $encryptedData]));
+            // Encrypt the JSON string using Laravel's encryption
+            $encryptedData = Crypt::encryptString($jsonData);
+            
+            // Wrap encrypted data in standard response format
+            $wrappedResponse = json_encode(
+                ['encrypted' => $encryptedData],
+                JSON_THROW_ON_ERROR
+            );
+            
+            $response->setContent($wrappedResponse);
+            
+        } catch (JsonException $e) {
+            // Handle JSON encoding/decoding failures 
+            // (usually due to invalid UTF-8 or circular references)
+            Log::error('JSON encoding error in encryption middleware: ' . $e->getMessage(), [
+                'exception' => $e,
+                'statusCode' => $response->getStatusCode()
+            ]);
+            return response()->json(
+                ['message' => 'Error processing response format'],
+                422
+            );
+            
+        } catch (EncryptException $e) {
+            // Handle encryption failures (usually due to key/cipher issues)
+            Log::error('Encryption error in middleware: ' . $e->getMessage(), [
+                'exception' => $e,
+                'statusCode' => $response->getStatusCode()
+            ]);
+            return response()->json(
+                ['message' => 'Error securing response'],
+                500
+            );
+            
+        } catch (\Exception $e) {
+            // Catch any unexpected errors to prevent exposure of system details
+            Log::error('Unexpected error in encryption middleware: ' . $e->getMessage(), [
+                'exception' => $e,
+                'statusCode' => $response->getStatusCode()
+            ]);
+            return response()->json(
+                ['message' => 'Internal server error'],
+                500
+            );
         }
 
         return $response;

--- a/backend/app/Models/ApiKey.php
+++ b/backend/app/Models/ApiKey.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Crypt;
+
+class ApiKey extends Model
+{
+    use HasFactory;
+
+    /**
+     * The primary key associated with the table.
+     *
+     * @var string
+     */
+    protected $primaryKey = 'api_keys_id';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'system',
+        'encrypted_key',
+        'is_active',
+        'key',
+    ];
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var array<int, string>
+     */
+    protected $hidden = [
+        'encrypted_key',
+    ];
+
+    /**
+     * Encrypt the API key before saving.
+     *
+     * @param  string  $value
+     * @return void
+     */
+    public function setKeyAttribute($value)
+    {
+        $this->attributes['encrypted_key'] = Crypt::encryptString($value);
+    }
+
+    /**
+     * Decrypt the API key when accessing it.
+     *
+     * @param  string  $value
+     * @return string|null
+     */
+    public function getKeyAttribute($value)
+    {
+        try {
+            return Crypt::decryptString($this->attributes['encrypted_key']);
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+}

--- a/backend/app/Models/Preference.php
+++ b/backend/app/Models/Preference.php
@@ -31,21 +31,25 @@ class Preference extends Model
     {
         return $this->belongsTo(ActiveSemester::class, 'active_semester_id');
     }
-    
+
     public function courseAssignment()
     {
         return $this->belongsTo(CourseAssignment::class, 'course_assignment_id');
     }
+
     public function course()
     {
         return $this->hasOneThrough(
             Course::class,
             CourseAssignment::class,
-            'course_assignment_id', // Foreign key on the CourseAssignment table
-            'course_id',            // Foreign key on the Course table
-            'course_assignment_id', // Local key on the Preferences table
-            'course_id'             // Local key on the CourseAssignment table
+            'course_assignment_id',
+            'course_id',
+            'course_assignment_id',
+            'course_id'
         );
     }
 
+    public function preferenceDays() {
+        return $this->hasMany(PreferenceDay::class, 'preference_id');
+    }
 }

--- a/backend/app/Models/Preference.php
+++ b/backend/app/Models/Preference.php
@@ -17,9 +17,6 @@ class Preference extends Model
         'faculty_id',
         'active_semester_id',
         'course_assignment_id',
-        'preferred_day',
-        'preferred_start_time',
-        'preferred_end_time',
     ];
 
     public function faculty()

--- a/backend/app/Models/PreferenceDay.php
+++ b/backend/app/Models/PreferenceDay.php
@@ -15,6 +15,8 @@ class PreferenceDay extends Model
     protected $fillable = [
         'preference_id',
         'preferred_day',
+        'preferred_start_time',
+        'preferred_end_time',
     ];
 
     public function preference()

--- a/backend/app/Models/PreferenceDay.php
+++ b/backend/app/Models/PreferenceDay.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PreferenceDay extends Model
+{
+    use HasFactory;
+
+    protected $table = 'preference_days';
+    protected $primaryKey = 'preference_day_id';
+
+    protected $fillable = [
+        'preference_id',
+        'preferred_day',
+    ];
+
+    public function preference()
+    {
+        return $this->belongsTo(Preference::class, 'preference_id');
+    }
+}

--- a/backend/app/Providers/RouteServiceProvider.php
+++ b/backend/app/Providers/RouteServiceProvider.php
@@ -25,7 +25,13 @@ class RouteServiceProvider extends ServiceProvider
     public function boot(): void
     {
         RateLimiter::for('api', function (Request $request) {
-            return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
+            return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip())
+            ->response(function ($request) {
+                return response()->json([
+                    'message' => 'Too many requests. Please wait before retrying.',
+                ])
+                ->header('Retry-After', 300);
+            });
         });
 
         $this->routes(function () {

--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -20,10 +20,11 @@ return [
     'allowed_methods' => ['GET', 'POST', 'PUT', 'DELETE'],
 
     'allowed_origins' => [
-        'https://app.pupt-flss.com',
-        'https://beta.pupt-flss.com',
-        'http://localhost:4200',
-        'http://127.0.0.1:4200',
+        '*',
+        // 'https://app.pupt-flss.com',
+        // 'https://beta.pupt-flss.com',
+        // 'http://localhost:4200',
+        // 'http://127.0.0.1:4200',
     ],
 
     'allowed_origins_patterns' => [],

--- a/backend/database/migrations/2024_09_09_005134_create_preferences_table.php
+++ b/backend/database/migrations/2024_09_09_005134_create_preferences_table.php
@@ -13,14 +13,9 @@ return new class extends Migration
             $table->unsignedBigInteger('faculty_id');
             $table->unsignedInteger('active_semester_id');
             $table->unsignedInteger('course_assignment_id');
-
-            $table->time('preferred_start_time');
-            $table->time('preferred_end_time');
-
             $table->timestamps();
 
             $table->unique(['faculty_id', 'active_semester_id', 'course_assignment_id'], 'unique_preference');
-
             $table->foreign('faculty_id')->references('id')->on('faculty')->onDelete('cascade');
             $table->foreign('active_semester_id')->references('active_semester_id')->on('active_semesters')->onDelete('cascade');
             $table->foreign('course_assignment_id')->references('course_assignment_id')->on('course_assignments')->onDelete('cascade');

--- a/backend/database/migrations/2024_09_09_005134_create_preferences_table.php
+++ b/backend/database/migrations/2024_09_09_005134_create_preferences_table.php
@@ -4,17 +4,16 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     public function up(): void
     {
         Schema::create('preferences', function (Blueprint $table) {
             $table->bigIncrements('preferences_id');
-            
             $table->unsignedBigInteger('faculty_id');
             $table->unsignedInteger('active_semester_id');
             $table->unsignedInteger('course_assignment_id');
 
-            $table->enum('preferred_day', ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday']);
             $table->time('preferred_start_time');
             $table->time('preferred_end_time');
 

--- a/backend/database/migrations/2024_12_09_213129_create_api_keys_table.php
+++ b/backend/database/migrations/2024_12_09_213129_create_api_keys_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('api_keys', function (Blueprint $table) {
+            $table->id('api_keys_id');
+            $table->string('system');
+            $table->string('encrypted_key', 500);
+            $table->tinyInteger('is_active')->default(1);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('api_keys');
+    }
+};

--- a/backend/database/migrations/2024_12_12_140422_create_preference_days_table.php
+++ b/backend/database/migrations/2024_12_12_140422_create_preference_days_table.php
@@ -1,24 +1,26 @@
-<?php
+    <?php
 
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
+    use Illuminate\Database\Migrations\Migration;
+    use Illuminate\Database\Schema\Blueprint;
+    use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
-    public function up(): void
-    {
-        Schema::create('preference_days', function (Blueprint $table) {
-            $table->id('preference_day_id');
-            $table->unsignedBigInteger('preference_id');
-            $table->enum('preferred_day', ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday']);
-            $table->timestamps();
+    return new class extends Migration {
+        public function up(): void
+        {
+            Schema::create('preference_days', function (Blueprint $table) {
+                $table->id('preference_day_id');
+                $table->unsignedBigInteger('preference_id');
+                $table->enum('preferred_day', ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday']);
+                $table->time('preferred_start_time');
+                $table->time('preferred_end_time');
+                $table->timestamps();
 
-            $table->foreign('preference_id')->references('preferences_id')->on('preferences')->onDelete('cascade');
-        });
-    }
+                $table->foreign('preference_id')->references('preferences_id')->on('preferences')->onDelete('cascade');
+            });
+        }
 
-    public function down(): void
-    {
-        Schema::dropIfExists('preference_days');
-    }
-};
+        public function down(): void
+        {
+            Schema::dropIfExists('preference_days');
+        }
+    };

--- a/backend/database/migrations/2024_12_12_140422_create_preference_days_table.php
+++ b/backend/database/migrations/2024_12_12_140422_create_preference_days_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('preference_days', function (Blueprint $table) {
+            $table->id('preference_day_id');
+            $table->unsignedBigInteger('preference_id');
+            $table->enum('preferred_day', ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday']);
+            $table->timestamps();
+
+            $table->foreign('preference_id')->references('preferences_id')->on('preferences')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('preference_days');
+    }
+};

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -23,7 +23,7 @@ class DatabaseSeeder extends Seeder
             CoursesTableSeeder::class,
             CourseAssignmentsTableSeeder::class,
             CourseRequirementsTableSeeder::class,
-            PreferencesSeeder::class,
+            // PreferencesSeeder::class,
             RoomsTableSeeder::class,
             SectionsPerProgramYearTableSeeder::class,
             SectionCoursesTableSeeder::class,

--- a/backend/database/sql/template/pupt_flss_official_v1.sql
+++ b/backend/database/sql/template/pupt_flss_official_v1.sql
@@ -1,6 +1,6 @@
--- PUPT-FLSS 2025 Official Database Schema (Version 1.7)
+-- PUPT-FLSS 2025 Official Database Schema (Version 1.8)
 -- Key Changes from the previous version:
--- (+) Add `global_start_date` and `individual_start_date` columns 
+-- (+) Add `api_keys` table
 
 -- Table structure for table `users`
 CREATE TABLE `users` (
@@ -313,4 +313,14 @@ CREATE TABLE `faculty_notifications` (
   `created_at` TIMESTAMP NULL DEFAULT NULL,
   `updated_at` TIMESTAMP NULL DEFAULT NULL,
   PRIMARY KEY (`faculty_notifications_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `api_keys` (
+  `api_keys_id` bigint UNSIGNED NOT NULL AUTO_INCREMENT,
+  `system` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `encrypted_key` varchar(500) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `is_active` tinyint NOT NULL DEFAULT '1',
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`api_keys_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/database/sql/template/pupt_flss_official_v1.sql
+++ b/backend/database/sql/template/pupt_flss_official_v1.sql
@@ -1,6 +1,7 @@
--- PUPT-FLSS 2025 Official Database Schema (Version 1.8)
+-- PUPT-FLSS 2025 Official Database Schema (Version 1.9)
 -- Key Changes from the previous version:
--- (+) Add `api_keys` table
+-- (+) Add `preference_days` table
+-- (*) Modify `preferences` table
 
 -- Table structure for table `users`
 CREATE TABLE `users` (
@@ -189,9 +190,6 @@ CREATE TABLE `preferences` (
   `faculty_id` bigint(20) UNSIGNED NOT NULL,
   `active_semester_id` int(10) UNSIGNED NOT NULL,
   `course_assignment_id` int(10) UNSIGNED NOT NULL,
-  `preferred_day` enum('Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday') COLLATE utf8mb4_unicode_ci NOT NULL,
-  `preferred_start_time` time NOT NULL,
-  `preferred_end_time` time NOT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`preferences_id`),
@@ -199,6 +197,19 @@ CREATE TABLE `preferences` (
   FOREIGN KEY (`faculty_id`) REFERENCES `faculty` (`id`) ON DELETE CASCADE,
   FOREIGN KEY (`active_semester_id`) REFERENCES `active_semesters` (`active_semester_id`) ON DELETE CASCADE,
   FOREIGN KEY (`course_assignment_id`) REFERENCES `course_assignments` (`course_assignment_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Table structure for table `preference_days`
+CREATE TABLE `preference_days` (
+  `preference_day_id` bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `preference_id` bigint(20) UNSIGNED NOT NULL,
+  `preferred_day` enum('Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `preferred_start_time` time NOT NULL,
+  `preferred_end_time` time NOT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`preference_day_id`),
+  FOREIGN KEY (`preference_id`) REFERENCES `preferences` (`preferences_id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Table structure for table `preferences_settings`

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -191,8 +191,7 @@ Route::prefix('external')->group(function () {
     /**
      * E-Class Record System (ECRS)
      */
-    Route::prefix('ecrs')->middleware(['encrypt.response', 'check.api.key:ecrs'])->group(function () {
-
+    Route::prefix('ecrs')->middleware(['check.hmac:ecrs'])->group(function () {
         // Version 1
         Route::prefix('v1')->group(function () {
             Route::get('/pupt-faculty-schedules', [ExternalController::class, 'ECRSFacultySchedules']);

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\CourseController;
 use App\Http\Controllers\CurriculumController;
 use App\Http\Controllers\CurriculumDetailsController;
 use App\Http\Controllers\EmailController;
+use App\Http\Controllers\ExternalController;
 use App\Http\Controllers\FacultyController;
 use App\Http\Controllers\FacultyNotificationController;
 use App\Http\Controllers\PreferenceController;
@@ -178,4 +179,19 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/year_levels/{id}', [YearLevelController::class, 'show']);
     Route::put('/updateYearLevel/{id}', [YearLevelController::class, 'update']);
     Route::delete('/deleteYearLevel/{id}', [YearLevelController::class, 'destroy']);
+});
+
+/*
+|----------------------------
+| External/Integration Routes
+|----------------------------
+ */
+Route::prefix('external')->middleware(['encrypt.response'])->group(function () {
+
+    /**
+     * E-Class Record System (ECRS)
+     */
+    Route::prefix('ecrs')->middleware('check.api.key:ecrs')->group(function () {
+        Route::get('/pupt-faculty-schedules', [ExternalController::class, 'ECRSFacultySchedules']);
+    });
 });

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -7,7 +7,7 @@ use App\Http\Controllers\CourseController;
 use App\Http\Controllers\CurriculumController;
 use App\Http\Controllers\CurriculumDetailsController;
 use App\Http\Controllers\EmailController;
-use App\Http\Controllers\ExternalController;
+use App\Http\Controllers\External\V1\ExternalController;
 use App\Http\Controllers\FacultyController;
 use App\Http\Controllers\FacultyNotificationController;
 use App\Http\Controllers\PreferenceController;
@@ -186,12 +186,16 @@ Route::middleware('auth:sanctum')->group(function () {
 | External/Integration Routes
 |----------------------------
  */
-Route::prefix('external')->middleware(['encrypt.response'])->group(function () {
+Route::prefix('external')->group(function () {
 
     /**
      * E-Class Record System (ECRS)
      */
-    Route::prefix('ecrs')->middleware('check.api.key:ecrs')->group(function () {
-        Route::get('/pupt-faculty-schedules', [ExternalController::class, 'ECRSFacultySchedules']);
+    Route::prefix('ecrs')->middleware(['encrypt.response', 'check.api.key:ecrs'])->group(function () {
+
+        // Version 1
+        Route::prefix('v1')->group(function () {
+            Route::get('/pupt-faculty-schedules', [ExternalController::class, 'ECRSFacultySchedules']);
+        });
     });
 });

--- a/frontend/src/app/core/animations/animations.ts
+++ b/frontend/src/app/core/animations/animations.ts
@@ -98,3 +98,67 @@ export const rowAdditionAnimation = trigger('rowAdditionAnimation', [
     ),
   ]),
 ]);
+
+export const cardSwipeAnimation = trigger('cardSwipeAnimation', [
+  transition(':increment', [
+    style({
+      transform: 'translateX(20%) translateY(0) scale(0.9)',
+      opacity: 0,
+      zIndex: 0,
+      filter: 'blur(4px)',
+    }),
+    animate(
+      '600ms cubic-bezier(0.23, 1, 0.32, 1)',
+      style({
+        transform: 'translateX(0) translateY(0) scale(1)',
+        opacity: 1,
+        zIndex: 1,
+        filter: 'blur(0)',
+      })
+    ),
+  ]),
+  transition(':decrement', [
+    style({
+      transform: 'translateX(-20%) translateY(0) scale(0.9)',
+      opacity: 0,
+      zIndex: 0,
+      filter: 'blur(4px)',
+    }),
+    animate(
+      '600ms cubic-bezier(0.23, 1, 0.32, 1)',
+      style({
+        transform: 'translateX(0) translateY(0) scale(1)',
+        opacity: 1,
+        zIndex: 1,
+        filter: 'blur(0)',
+      })
+    ),
+  ]),
+]);
+
+export const showHideFieldsAnimation = trigger('showHideFieldsAnimation', [
+  state(
+    'visible',
+    style({
+      opacity: 1,
+      height: '*',
+      transform: 'translateY(0)',
+      overflow: 'hidden',
+    })
+  ),
+  state(
+    'hidden',
+    style({
+      opacity: 0,
+      height: '0px',
+      transform: 'translateY(-10px)',
+      overflow: 'hidden',
+    })
+  ),
+  transition('visible => hidden', [
+    animate('300ms cubic-bezier(0.4, 0.0, 0.2, 1)'),
+  ]),
+  transition('hidden => visible', [
+    animate('300ms cubic-bezier(0.4, 0.0, 0.2, 1)'),
+  ]),
+]);

--- a/frontend/src/app/core/components/admin/faculty-pref/faculty-pref.component.ts
+++ b/frontend/src/app/core/components/admin/faculty-pref/faculty-pref.component.ts
@@ -619,18 +619,31 @@ export class FacultyPrefComponent implements OnInit, AfterViewInit {
       currentY += 5;
 
       const courseData = activeSemester.courses.map(
-        (course: any, index: number) => [
-          (index + 1).toString(),
-          course.course_details?.course_code || 'N/A',
-          course.course_details?.course_title || 'N/A',
-          course.lec_hours.toString(),
-          course.lab_hours.toString(),
-          course.units.toString(),
-          course.preferred_day,
-          `${this.formatTimeTo12Hour(
-            course.preferred_start_time
-          )} - ${this.formatTimeTo12Hour(course.preferred_end_time)}`,
-        ]
+        (course: any, index: number) => {
+          const preferredDays = course.preferred_days || [];
+          const formattedDayTimes = preferredDays
+            .map((pd: any) => {
+              const day = pd.day;
+              const startTime = pd.start_time
+                ? this.formatTimeTo12Hour(pd.start_time)
+                : 'N/A';
+              const endTime = pd.end_time
+                ? this.formatTimeTo12Hour(pd.end_time)
+                : 'N/A';
+              return `${day} - ${startTime} to ${endTime}`;
+            })
+            .join('\n');
+
+          return [
+            (index + 1).toString(),
+            course.course_details?.course_code || 'N/A',
+            course.course_details?.course_title || 'N/A',
+            course.lec_hours.toString(),
+            course.lab_hours.toString(),
+            course.units.toString(),
+            formattedDayTimes || 'N/A',
+          ];
+        }
       );
 
       // Table Configuration
@@ -642,8 +655,7 @@ export class FacultyPrefComponent implements OnInit, AfterViewInit {
           'Lec',
           'Lab',
           'Units',
-          'Preferred Day',
-          'Preferred Time',
+          'Preferred Day & Time',
         ],
       ];
       const tableConfig = {
@@ -672,8 +684,7 @@ export class FacultyPrefComponent implements OnInit, AfterViewInit {
           3: { cellWidth: 13 },
           4: { cellWidth: 13 },
           5: { cellWidth: 13 },
-          6: { cellWidth: 25 },
-          7: { cellWidth: 35 },
+          6: { cellWidth: 55 },
         },
         margin: { left: margin, right: margin },
       };
@@ -722,7 +733,10 @@ export class FacultyPrefComponent implements OnInit, AfterViewInit {
   /**
    * Formats time from 24-hour to 12-hour format.
    */
-  formatTimeTo12Hour(time: string): string {
+  formatTimeTo12Hour(time: string | undefined): string {
+    if (!time) {
+      return 'N/A';
+    }
     const [hour, minute] = time.split(':');
     const hours = parseInt(hour, 10);
     const minutesFormatted = minute.length === 2 ? minute : `0${minute}`;

--- a/frontend/src/app/core/components/admin/overview/overview.component.ts
+++ b/frontend/src/app/core/components/admin/overview/overview.component.ts
@@ -47,6 +47,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
     { curriculum_id: 0, curriculum_year: '0' },
   ];
   globalDeadline: string | null = null;
+  globalStartDate: string | null = null;
 
   // Progress metrics
   preferencesProgress = 0;
@@ -130,6 +131,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
     this.preferencesEnabled = data.preferencesSubmissionEnabled;
     this.schedulesPublished = data.publishProgress > 0;
     this.globalDeadline = data.global_deadline || null;
+    this.globalStartDate = data.global_start_date || null;
   }
 
   private resetProgressMetrics(): void {
@@ -160,6 +162,10 @@ export class OverviewComponent implements OnInit, OnDestroy {
       ? new Date(this.globalDeadline)
       : null;
 
+    const StartDate = this.globalStartDate
+    ? new Date(this.globalStartDate)
+    : null;
+
     const dialogData: DialogActionData = {
       type: 'all_preferences',
       academicYear: this.activeYear,
@@ -167,6 +173,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
       hasSecondaryText: true,
       currentState: this.preferencesEnabled,
       global_deadline: deadlineDate,
+      global_start_date: StartDate,
     };
 
     const dialogRef = this.dialog.open(DialogActionComponent, {

--- a/frontend/src/app/core/components/admin/scheduling/scheduling.component.html
+++ b/frontend/src/app/core/components/admin/scheduling/scheduling.component.html
@@ -184,21 +184,15 @@
                 [disabled]="loadingScheduleId === element.schedule_id"
               >
                 <div class="button-content">
-                  <ng-container
-                    *ngIf="
-                      loadingScheduleId === element.schedule_id;
-                      else editIcon
-                    "
-                  >
-                    <mat-spinner
-                      class="custom-spinner"
-                      diameter="25"
-                    ></mat-spinner>
-                  </ng-container>
-                  <ng-template #editIcon>
-                    <mat-icon>edit</mat-icon>
-                    <span>Edit</span>
-                  </ng-template>
+                  @if (loadingScheduleId === element.schedule_id) {
+                  <mat-spinner
+                    class="custom-spinner"
+                    diameter="25"
+                  ></mat-spinner>
+                  } @else {
+                  <mat-icon>edit</mat-icon>
+                  <span>Edit</span>
+                  }
                 </div>
               </button>
             </div>

--- a/frontend/src/app/core/components/admin/scheduling/scheduling.component.ts
+++ b/frontend/src/app/core/components/admin/scheduling/scheduling.component.ts
@@ -824,7 +824,7 @@ export class SchedulingComponent implements OnInit, OnDestroy {
         });
 
         const dialogRef = this.dialog.open(DialogSchedulingComponent, {
-          maxWidth: '45rem',
+          maxWidth: '50rem',
           width: '100%',
           disableClose: true,
           data: {

--- a/frontend/src/app/core/components/admin/scheduling/scheduling.component.ts
+++ b/frontend/src/app/core/components/admin/scheduling/scheduling.component.ts
@@ -764,12 +764,23 @@ export class SchedulingComponent implements OnInit, OnDestroy {
         const selectedProgramInfo = `${schedule.program_code} ${schedule.year}-${schedule.section}`;
         const selectedCourseInfo = `${schedule.course_code} - ${schedule.course_title}`;
 
-        const suggestedFaculty: {
-          name: string;
-          type: string;
+        // =======================
+        // Updated SuggestedFaculty
+        // =======================
+        interface Preference {
           day: string;
           time: string;
-        }[] = [];
+        }
+
+        interface SuggestedFaculty {
+          faculty_id: number;
+          name: string;
+          type: string;
+          preferences: Preference[];
+          prefIndex: number;
+        }
+
+        const suggestedFaculty: SuggestedFaculty[] = [];
 
         preferences.preferences.forEach((pref) => {
           const facultyDetails = faculty.faculty.find(
@@ -785,16 +796,28 @@ export class SchedulingComponent implements OnInit, OnDestroy {
           pref.active_semesters.forEach((semester) => {
             semester.courses.forEach((course) => {
               if (course.course_details.course_id === schedule.course_id) {
-                suggestedFaculty.push({
+                const existingFaculty = suggestedFaculty.find(
+                  (f) => f.faculty_id === facultyDetails.faculty_id
+                );
+
+                const facultyPref: SuggestedFaculty = {
+                  faculty_id: facultyDetails.faculty_id,
                   name: pref.faculty_name,
                   type: facultyDetails.faculty_type,
-                  day: course.preferred_day,
-                  time: `${this.formatTimeFromBackend(
-                    course.preferred_start_time
-                  )} - ${this.formatTimeFromBackend(
-                    course.preferred_end_time
-                  )}`,
-                });
+                  preferences: course.preferred_days.map((prefDay) => ({
+                    day: prefDay.day,
+                    time: `${this.formatTimeFromBackend(
+                      prefDay.start_time
+                    )} - ${this.formatTimeFromBackend(prefDay.end_time)}`,
+                  })),
+                  prefIndex: 0,
+                };
+
+                if (existingFaculty) {
+                  existingFaculty.preferences.push(...facultyPref.preferences);
+                } else {
+                  suggestedFaculty.push(facultyPref);
+                }
               }
             });
           });

--- a/frontend/src/app/core/components/faculty/home/home.component.scss
+++ b/frontend/src/app/core/components/faculty/home/home.component.scss
@@ -9,8 +9,6 @@
   @include mixins.flex-layout(
     $align: stretch,
     $justify: center,
-    // $justify: flex-start,
-    $direction: column,
     $gap: var(--spacing-lg)
   );
   height: 100%;
@@ -205,35 +203,5 @@
         }
       }
     }
-  }
-}
-
-/* For Mobile Responsive */
-@media (max-width: 768px) {
-  .home-row-one,
-  .home-row-two {
-    flex-direction: column;
-    padding: var(--spacing-sm);
-  }
-
-  #home_greetings h1 {
-    font-size: var(--font-size-md);
-  }
-
-  .faculty-calendar .full-calendar {
-    max-height: 20rem;
-    overflow-y: auto;
-  }
-
-  .active-year-sem-container {
-    padding: var(--spacing-xs);
-    font-size: var(--font-size-md);
-    text-align: center;
-  }
-
-  .faculty-announcement {
-    font-size: var(--font-size-sm);
-    padding: var(--spacing-sm);
-    text-align: center;
   }
 }

--- a/frontend/src/app/core/components/faculty/home/home.component.scss
+++ b/frontend/src/app/core/components/faculty/home/home.component.scss
@@ -1,4 +1,5 @@
 @use "../../../../../styles/mixins";
+
 * {
   @include mixins.reset-styles;
   @include mixins.default-transition;

--- a/frontend/src/app/core/components/faculty/preferences/preferences.component.html
+++ b/frontend/src/app/core/components/faculty/preferences/preferences.component.html
@@ -195,18 +195,6 @@
           </td>
         </ng-container>
 
-        <!-- # Column -->
-        <!-- <ng-container matColumnDef="num">
-          <th mat-header-cell *matHeaderCellDef class="table-header">#</th>
-          <td
-            mat-cell
-            *matCellDef="let element; let i = index"
-            class="table-cell"
-          >
-            {{ i + 1 }}
-          </td>
-        </ng-container> -->
-
         <!-- Course Code Column -->
         <ng-container matColumnDef="course_code">
           <th mat-header-cell *matHeaderCellDef class="table-header">
@@ -265,15 +253,7 @@
               >
                 <mat-icon fontSet="material-icons-round">today</mat-icon>
                 <span class="display-day-time">
-                  {{
-                    element.preferredDay && element.preferredTime
-                      ? element.preferredDay +
-                        ", " +
-                        (element.preferredTime === "07:00 AM - 09:00 PM"
-                          ? "Whole Day"
-                          : (element.preferredTime | timeFormat))
-                      : "Click to select day & time"
-                  }}
+                  {{ formatSelectedDaysAndTime(element) }}
                 </span>
               </button>
             </div>

--- a/frontend/src/app/core/components/faculty/preferences/preferences.component.html
+++ b/frontend/src/app/core/components/faculty/preferences/preferences.component.html
@@ -184,7 +184,11 @@
               class="remove-button"
               (click)="removeCourse(element)"
             >
+              @if (isRemoving[element.course_code]) {
+              <mat-spinner class="custom-spinner" diameter="20"></mat-spinner>
+              } @else {
               <span mat-symbol="do_not_disturb_on" variant="outlined"></span>
+              }
             </button>
           </td>
         </ng-container>

--- a/frontend/src/app/core/components/faculty/preferences/preferences.component.html
+++ b/frontend/src/app/core/components/faculty/preferences/preferences.component.html
@@ -25,11 +25,6 @@
 
     @if(isPreferencesEnabled) {
     <div id="total_container" [class.disabled]="!isPreferencesEnabled">
-      <!-- <div class="units max" [@fadeAnimation]>
-                <h2>{{ maxUnits }}</h2>
-                <span>Max. Units Allowed</span>
-              </div> -->
-      <!-- Total Units-->
       <div class="total units" [@fadeAnimation]>
         <h2>{{ totalUnits }}</h2>
         <span>Total Units Selected</span>
@@ -270,47 +265,6 @@
           </td>
         </tr>
       </table>
-
-      <!--Table Pseudo Footer-->
-      <div class="table-footer">
-        <!-- Remove All Button -->
-        <div
-          class="button-container"
-          (click)="!isRemoveDisabled && removeAllCourses()"
-          [matTooltip]="
-            isRemoveDisabled ? 'You must select at least one course.' : ''
-          "
-          [class.disabled]="isRemoveDisabled || isRemovingAll"
-        >
-          @if (!isRemovingAll) {
-          <span mat-symbol="delete_sweep" class="remove"></span>
-          <span class="button-text remove">Remove all</span>
-          } @else {
-          <mat-spinner class="custom-spinner" diameter="20"></mat-spinner>
-          <span class="button-text remove">Remove all</span>
-          }
-        </div>
-
-        <!-- Submit Preferences Button -->
-        <div
-          class="button-container"
-          (click)="!isSubmitDisabled && submitPreferences()"
-          [matTooltip]="
-            isSubmitDisabled
-              ? 'Select one or more courses and ensure each has a selected day and time.'
-              : ''
-          "
-          [class.disabled]="isSubmitDisabled"
-        >
-          @if (!isSubmitting) {
-          <span class="button-text submit">Submit Preferences</span>
-          <span mat-symbol="done_all" class="submit"></span>
-          } @else {
-          <span class="button-text submit">Submit Preferences</span>
-          <mat-spinner class="custom-spinner-two" diameter="20"></mat-spinner>
-          }
-        </div>
-      </div>
     </div>
     }
     <!-- If preferences are disabled, display the closed submission UI -->

--- a/frontend/src/app/core/components/faculty/preferences/preferences.component.html
+++ b/frontend/src/app/core/components/faculty/preferences/preferences.component.html
@@ -123,7 +123,7 @@
         </h3>
         <div class="programs-scroll-container">
           <div [@cardEntranceAnimation]="programs.length">
-            @for (program of programs; track trackByProgramId($index, program)){
+            @for (program of programs; track program.program_id) {
             <div
               class="program-card pop"
               (click)="selectProgram(program)"
@@ -150,8 +150,7 @@
         </h3>
         <div class="courses-scroll-container">
           <div [@cardEntranceAnimation]="filteredCourses.length">
-            @for (course of filteredCourses; track trackByCourseId($index,
-            course)) {
+            @for (course of filteredCourses; track course.course_id) {
             <div
               class="course-card pop"
               (click)="addCourseToTable(course)"
@@ -239,23 +238,21 @@
           </td>
         </ng-container>
 
-        <!-- Available Day & Time Column -->
-        <ng-container matColumnDef="availableDayTime">
+        <!-- Preferred Day & Time Column -->
+        <ng-container matColumnDef="preferredDayTime">
           <th mat-header-cell *matHeaderCellDef class="table-header">
-            Available Day & Time
+            Preferred Day & Time
           </th>
           <td mat-cell *matCellDef="let element" class="table-cell picker-cell">
             <div class="day-time-button-container">
-              <button
-                mat-button
+              <div
                 (click)="openDayTimeDialog(element)"
                 class="day-time-button"
               >
-                <mat-icon fontSet="material-icons-round">today</mat-icon>
                 <span class="display-day-time">
                   {{ formatSelectedDaysAndTime(element) }}
                 </span>
-              </button>
+              </div>
             </div>
           </td>
         </ng-container>

--- a/frontend/src/app/core/components/faculty/preferences/preferences.component.html
+++ b/frontend/src/app/core/components/faculty/preferences/preferences.component.html
@@ -245,10 +245,7 @@
           </th>
           <td mat-cell *matCellDef="let element" class="table-cell picker-cell">
             <div class="day-time-button-container">
-              <div
-                (click)="openDayTimeDialog(element)"
-                class="day-time-button"
-              >
+              <div (click)="openDayTimeDialog(element)" class="day-time-button">
                 <span class="display-day-time">
                   {{ formatSelectedDaysAndTime(element) }}
                 </span>

--- a/frontend/src/app/core/components/faculty/preferences/preferences.component.scss
+++ b/frontend/src/app/core/components/faculty/preferences/preferences.component.scss
@@ -269,16 +269,11 @@
     background-color: var(--neutral-light);
 
     .day-time-button-container {
-      @include mixins.flex-layout($justify: flex-start);
+      @include mixins.flex-layout;
 
       .day-time-button {
-        @include mixins.flex-layout;
         color: var(--primary-text);
-      }
-
-      mat-icon {
-        @include mixins.flex-layout;
-        padding: var(--spacing-sm);
+        cursor: pointer;
       }
     }
 

--- a/frontend/src/app/core/components/faculty/preferences/preferences.component.scss
+++ b/frontend/src/app/core/components/faculty/preferences/preferences.component.scss
@@ -6,7 +6,6 @@
 
 :host {
   @include mixins.custom-spinner;
-  @include mixins.custom-spinner-two();
 }
 
 .faculty-preferences-container {

--- a/frontend/src/app/core/components/faculty/preferences/preferences.component.ts
+++ b/frontend/src/app/core/components/faculty/preferences/preferences.component.ts
@@ -396,19 +396,17 @@ export class PreferencesComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private searchCourses(query: string): Course[] {
     const uniqueCourses = new Set<string>();
-    return (
-      this.showProgramSelection
-        ? this.programs.flatMap((program) =>
-            program.year_levels.flatMap((yl) => yl.semester.courses)
-          )
-        : this.filteredCourses
-    ).filter(
-      (course) =>
-        (course.course_code.toLowerCase().includes(query) ||
-          course.course_title.toLowerCase().includes(query)) &&
-        !uniqueCourses.has(course.course_code) &&
-        uniqueCourses.add(course.course_code)
-    );
+    return this.programs
+      .flatMap((program) =>
+        program.year_levels.flatMap((yl) => yl.semester.courses)
+      )
+      .filter(
+        (course) =>
+          (course.course_code.toLowerCase().includes(query) ||
+            course.course_title.toLowerCase().includes(query)) &&
+          !uniqueCourses.has(course.course_code) &&
+          uniqueCourses.add(course.course_code)
+      );
   }
 
   clearSearch(): void {
@@ -419,7 +417,6 @@ export class PreferencesComponent implements OnInit, AfterViewInit, OnDestroy {
     this.cdr.markForCheck();
   }
 
-  
   // ===========================
   // Course Management
   // ===========================

--- a/frontend/src/app/core/components/faculty/preferences/preferences.component.ts
+++ b/frontend/src/app/core/components/faculty/preferences/preferences.component.ts
@@ -18,8 +18,6 @@ import { MatRippleModule } from '@angular/material/core';
 import { MatSymbolDirective } from '../../../imports/mat-symbol.directive';
 
 import { DialogDayTimeComponent } from '../../../../shared/dialog-day-time/dialog-day-time.component';
-import { DialogGenericComponent, DialogData } from '../../../../shared/dialog-generic/dialog-generic.component';
-import { DialogPrefSuccessComponent } from '../../../../shared/dialog-pref-success/dialog-pref-success.component';
 import { DialogPrefComponent } from '../../../../shared/dialog-pref/dialog-pref.component';
 import { DialogRequestAccessComponent } from '../../../../shared/dialog-request-access/dialog-request-access.component';
 import { LoadingComponent } from '../../../../shared/loading/loading.component';

--- a/frontend/src/app/core/components/superadmin/maintenance/curriculum/curriculum-detail/curriculum-detail.component.ts
+++ b/frontend/src/app/core/components/superadmin/maintenance/curriculum/curriculum-detail/curriculum-detail.component.ts
@@ -11,7 +11,6 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { TableGenericComponent } from '../../../../../../shared/table-generic/table-generic.component';
 import { TableHeaderComponent, InputField } from '../../../../../../shared/table-header/table-header.component';
 import { TableDialogComponent, DialogConfig } from '../../../../../../shared/table-dialog/table-dialog.component';
-import { DialogGenericComponent } from '../../../../../../shared/dialog-generic/dialog-generic.component';
 import { DialogExportComponent } from '../../../../../../shared/dialog-export/dialog-export.component';
 import { LoadingComponent } from '../../../../../../shared/loading/loading.component';
 import { fadeAnimation, pageFloatUpAnimation } from '../../../../../animations/animations';
@@ -33,7 +32,6 @@ import {
     CommonModule,
     TableGenericComponent,
     TableHeaderComponent,
-    DialogGenericComponent,
     LoadingComponent
   ],
   templateUrl: './curriculum-detail.component.html',

--- a/frontend/src/app/core/models/scheduling.model.ts
+++ b/frontend/src/app/core/models/scheduling.model.ts
@@ -1,220 +1,221 @@
 export interface Program {
-    program_id: number;
-    program_code: string;
-    program_title: string;
-    year_levels: YearLevel[];
-    sections: { [yearLevel: string]: number };
-    curriculums: { [yearLevel: string]: string };
-  }
-  
-  export interface Section {
-    section_id: number;
-    section_name: string;
-  }
-  
-  export interface SectionsByProgram {
-    [program: string]: {
-      [year: number]: string[];
-    };
-  }
-  
-  export interface Curriculum {
-    id: number;
-    curriculum_year: string;
-    name: string;
-  }
-  
-  export interface Schedule {
-    course_id: number;
-    course_code: string;
-    course_title: string;
-    lec_hours: number;
-    lab_hours: number;
-    units: number;
-    tuition_hours: number;
+  program_id: number;
+  program_code: string;
+  program_title: string;
+  year_levels: YearLevel[];
+  sections: { [yearLevel: string]: number };
+  curriculums: { [yearLevel: string]: string };
+}
+
+export interface Section {
+  section_id: number;
+  section_name: string;
+}
+
+export interface SectionsByProgram {
+  [program: string]: {
+    [year: number]: string[];
+  };
+}
+
+export interface Curriculum {
+  id: number;
+  curriculum_year: string;
+  name: string;
+}
+
+export interface Schedule {
+  course_id: number;
+  course_code: string;
+  course_title: string;
+  lec_hours: number;
+  lab_hours: number;
+  units: number;
+  tuition_hours: number;
+  day: string;
+  time: string;
+  professor: string;
+  room: string;
+  program: string;
+  program_code: string;
+  year: number;
+  curriculum: string;
+  section: string;
+
+  schedule_id?: number;
+  faculty_id?: number;
+  faculty_email?: string;
+  room_id?: number;
+  section_course_id: number;
+  is_copy: number;
+}
+
+export interface Semester {
+  semester_id: number;
+  semester_number: string;
+  semester: number;
+  start_date: string;
+  end_date: string;
+  courses: Schedule[];
+}
+
+export interface AcademicYear {
+  academic_year_id: number;
+  academic_year: string;
+  semesters: Semester[];
+}
+
+export interface YearLevel {
+  year_level: number;
+  curriculum_id: number;
+  curriculum_year: string;
+  number_of_sections: number;
+  sections: Section[];
+  semesters: Semester[];
+}
+
+export interface PopulateSchedulesResponse {
+  active_semester_id: number;
+  academic_year_id: number;
+  semester_id: number;
+  is_submission_enabled: number;
+  programs: ProgramResponse[];
+}
+
+export interface ProgramResponse {
+  program_id: number;
+  program_code: string;
+  program_title: string;
+  year_levels: YearLevelResponse[];
+}
+
+export interface YearLevelResponse {
+  year_level: number;
+  curriculum_id: number;
+  curriculum_year: string;
+  semesters: SemesterResponse[];
+}
+
+export interface SemesterResponse {
+  semester: number;
+  sections: SectionResponse[];
+}
+
+export interface SectionResponse {
+  section_per_program_year_id: number;
+  section_name: string;
+  courses: CourseResponse[];
+}
+
+export interface CourseResponse {
+  course_assignment_id: number;
+  course_id: number;
+  course_code: string;
+  course_title: string;
+  lec_hours: number;
+  lab_hours: number;
+  units: number;
+  tuition_hours: number;
+  schedule?: {
+    schedule_id: number;
     day: string;
-    time: string;
-    professor: string;
-    room: string;
-    program: string;
-    program_code: string;
-    year: number;
-    curriculum: string;
-    section: string;
-  
-    schedule_id?: number;
-    faculty_id?: number;
-    faculty_email?: string;
+    start_time: string;
+    end_time: string;
     room_id?: number;
-    section_course_id: number;
-    is_copy: number;
-  }
-  
-  export interface Semester {
-    semester_id: number;
-    semester_number: string;
-    semester: number;
-    start_date: string;
-    end_date: string;
-    courses: Schedule[];
-  }
-  
-  export interface AcademicYear {
-    academic_year_id: number;
-    academic_year: string;
-    semesters: Semester[];
-  }
-  
-  export interface YearLevel {
-    year_level: number;
-    curriculum_id: number;
-    curriculum_year: string;
-    number_of_sections: number;
-    sections: Section[];
-    semesters: Semester[];
-  }
-  
-  export interface PopulateSchedulesResponse {
-    active_semester_id: number;
-    academic_year_id: number;
-    semester_id: number;
-    is_submission_enabled: number;
-    programs: ProgramResponse[];
-  }
-  
-  export interface ProgramResponse {
-    program_id: number;
-    program_code: string;
-    program_title: string;
-    year_levels: YearLevelResponse[];
-  }
-  
-  export interface YearLevelResponse {
-    year_level: number;
-    curriculum_id: number;
-    curriculum_year: string;
-    semesters: SemesterResponse[];
-  }
-  
-  export interface SemesterResponse {
-    semester: number;
-    sections: SectionResponse[];
-  }
-  
-  export interface SectionResponse {
-    section_per_program_year_id: number;
-    section_name: string;
-    courses: CourseResponse[];
-  }
-  
-  export interface CourseResponse {
-    course_assignment_id: number;
-    course_id: number;
-    course_code: string;
-    course_title: string;
-    lec_hours: number;
-    lab_hours: number;
-    units: number;
-    tuition_hours: number;
-    schedule?: {
-      schedule_id: number;
-      day: string;
-      start_time: string;
-      end_time: string;
-      room_id?: number;
-    };
-    professor: string;
-    faculty_id: number;
-    faculty_email: string;
-    room?: {
-      room_id: number;
-      room_code: string;
-    };
-    section_course_id: number;
-    is_copy?: number;
-  }
-  
-  export interface Room {
+  };
+  professor: string;
+  faculty_id: number;
+  faculty_email: string;
+  room?: {
     room_id: number;
     room_code: string;
-    location: string;
-    floor_level: string;
-    room_type: string;
-    capacity: number;
-    status: string;
-  }
-  
-  export interface Faculty {
-    faculty_id: number;
-    name: string;
-    faculty_email: string;
-    faculty_type: string;
-    faculty_units: number;
-  }
-  
-  export interface SubmittedPrefResponse {
-    preferences: Preference[];
-  }
-  
-  export interface Preference {
-    faculty_id: number;
-    faculty_name: string;
-    faculty_code: string;
-    faculty_units: string;
-    active_semesters: ActiveSemester[];
-  }
-  
-  export interface ActiveSemester {
-    active_semester_id: number;
-    academic_year_id: number;
-    academic_year: string;
-    semester_id: number;
-    semester_label: string;
-    courses: CoursePreference[];
-  }
-  
-  export interface CoursePreference {
-    course_assignment_id: number;
-    course_details: CourseDetails;
-    preferred_day: string;
-    preferred_start_time: string;
-    preferred_end_time: string;
-    created_at: string;
-    updated_at: string;
-  }
-  
-  export interface CourseDetails {
-    course_id: number;
-    course_code: string;
-    course_title: string;
-  }
-  
-  export interface ConflictingCourseDetail {
-    course: CourseResponse;
-    sectionName: string;
-  }
-  
-  export interface ConflictingScheduleDetail {
-    course: CourseResponse;
-    programCode: string;
-    yearLevel: number;
-    sectionName: string;
-  }
-  
-  export interface ProgramOption {
-    display: string;
-    id: number;
-    year_levels: YearLevelOption[];
-  }
-  
-  export interface YearLevelOption {
-    year_level: number;
-    curriculum_id: number;
-    sections: SectionOption[];
-  }
-  
-  export interface SectionOption {
-    section_id: number;
-    section_name: string;
-  }
-  
+  };
+  section_course_id: number;
+  is_copy?: number;
+}
+
+export interface Room {
+  room_id: number;
+  room_code: string;
+  location: string;
+  floor_level: string;
+  room_type: string;
+  capacity: number;
+  status: string;
+}
+
+export interface Faculty {
+  faculty_id: number;
+  name: string;
+  faculty_email: string;
+  faculty_type: string;
+  faculty_units: number;
+}
+
+export interface SubmittedPrefResponse {
+  preferences: Preference[];
+}
+
+export interface Preference {
+  faculty_id: number;
+  faculty_name: string;
+  faculty_code: string;
+  faculty_units: string;
+  active_semesters: ActiveSemester[];
+}
+
+export interface ActiveSemester {
+  active_semester_id: number;
+  academic_year_id: number;
+  academic_year: string;
+  semester_id: number;
+  semester_label: string;
+  courses: CoursePreference[];
+}
+
+export interface CoursePreference {
+  course_assignment_id: number;
+  course_details: CourseDetails;
+  preferred_days: {
+    day: string;
+    start_time: string;
+    end_time: string;
+  }[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CourseDetails {
+  course_id: number;
+  course_code: string;
+  course_title: string;
+}
+
+export interface ConflictingCourseDetail {
+  course: CourseResponse;
+  sectionName: string;
+}
+
+export interface ConflictingScheduleDetail {
+  course: CourseResponse;
+  programCode: string;
+  yearLevel: number;
+  sectionName: string;
+}
+
+export interface ProgramOption {
+  display: string;
+  id: number;
+  year_levels: YearLevelOption[];
+}
+
+export interface YearLevelOption {
+  year_level: number;
+  curriculum_id: number;
+  sections: SectionOption[];
+}
+
+export interface SectionOption {
+  section_id: number;
+  section_name: string;
+}

--- a/frontend/src/app/core/services/admin/overview/overview.service.ts
+++ b/frontend/src/app/core/services/admin/overview/overview.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { environment } from '../../../../../environments/environment.dev';
 
 export interface OverviewDetails {
+  global_start_date: null;
   activeAcademicYear: string;
   activeSemester: string;
   activeFacultyCount: number;

--- a/frontend/src/app/core/services/faculty/preference/preferences.service.ts
+++ b/frontend/src/app/core/services/faculty/preference/preferences.service.ts
@@ -169,14 +169,19 @@ export class PreferencesService {
   }
 
   /**
-   * Submits user preferences and clears relevant caches upon success.
+   * Submits a single preference for a faculty member.
    */
-  submitPreferences(preferences: any): Observable<any> {
+  submitSinglePreference(preference: {
+    faculty_id: number;
+    active_semester_id: number;
+    course_assignment_id: number;
+    preferred_days: PreferredDay[];
+  }): Observable<any> {
     const url = `${this.baseUrl}/submit-preferences`;
-    return this.http.post(url, preferences).pipe(
-      tap(() => this.clearCaches(preferences.faculty_id.toString())),
+    return this.http.post(url, preference).pipe(
+      tap(() => this.clearCaches(preference.faculty_id.toString())),
       catchError((error) => {
-        console.error('Error submitting preferences:', error);
+        console.error('Error submitting single preference:', error);
         return throwError(() => error);
       })
     );

--- a/frontend/src/app/core/services/faculty/preference/preferences.service.ts
+++ b/frontend/src/app/core/services/faculty/preference/preferences.service.ts
@@ -6,6 +6,12 @@ import { map, shareReplay, tap, take, catchError } from 'rxjs/operators';
 
 import { environment } from '../../../../../environments/environment.dev';
 
+export interface PreferredDay {
+  day: string;
+  start_time: string;
+  end_time: string;
+}
+
 export interface Course {
   course_assignment_id: number;
   course_id: number;
@@ -17,8 +23,8 @@ export interface Course {
   lab_hours: number;
   units: number;
   tuition_hours: number;
+  preferred_days?: PreferredDay[];
 }
-
 export interface ActiveSemester {
   active_semester_id: number;
   academic_year_id: number;

--- a/frontend/src/app/shared/dialog-action/dialog-action.component.html
+++ b/frontend/src/app/shared/dialog-action/dialog-action.component.html
@@ -92,25 +92,23 @@
           required
           (click)="startPicker.open()"
         />
-        <mat-datepicker-toggle matIconSuffix [for]="startPicker">
-        </mat-datepicker-toggle>
+        <mat-datepicker-toggle
+          matIconSuffix
+          [for]="startPicker"
+        ></mat-datepicker-toggle>
         <mat-datepicker #startPicker></mat-datepicker>
 
+        <!-- Simplified logic for Start Date mat-hint -->
         @if (data.type === 'all_preferences' || data.type ===
         'single_preferences') {
-        <mat-hint>
-          @if (data.currentState) { Current Set Start Date: @if
-          (isStartDateToday) {
-          <strong>{{ getStartDateText(true) }}</strong>
-          } @else {
-          {{ startDate | date }}
-          <strong>({{ remainingDaysStart }} day(s) left)</strong>
-          } } @else { The submission will start @if (isStartDateToday) {
-          <strong>{{ getStartDateText(false) }}</strong>
-          } @else {
-          <strong>{{ remainingDaysStart }} day(s)</strong> from now } }
+        <mat-hint *ngIf="!data.currentState">
+          The submission will start @if (isStartDateToday) {
+          <strong>today, immediately</strong>
+          } @else { in <strong>{{ remainingDaysStart }} day(s)</strong>
+          }
         </mat-hint>
         }
+        <!-- no mat-hint if data.currentState === true -->
       </mat-form-field>
     </div>
     }
@@ -131,26 +129,24 @@
           required
           (click)="endPicker.open()"
         />
-        <mat-datepicker-toggle matIconSuffix [for]="endPicker">
-        </mat-datepicker-toggle>
+        <mat-datepicker-toggle
+          matIconSuffix
+          [for]="endPicker"
+        ></mat-datepicker-toggle>
         <mat-datepicker #endPicker></mat-datepicker>
 
+        <!-- Simplified logic for End Date mat-hint -->
         @if (data.type === 'all_preferences' || data.type ===
         'single_preferences') {
-        <mat-hint>
-          @if (data.currentState) { Current Set Submission Deadline: @if
-          (isDeadlineToday) {
-          <strong>{{ getDeadlineText(true) }}</strong>
+        <mat-hint *ngIf="data.currentState">
+          The submission is set to close in @if (isDeadlineToday) {
+          <strong>today at 11:59 PM</strong>
           } @else {
-          {{ submissionDeadline | date }}
-          <strong>({{ remainingDays }} day(s) left)</strong>
-          } } @else { The submission will close @if (isDeadlineToday) {
-          <strong>{{ getDeadlineText(false) }}</strong>
-          } @else {
-          <strong>{{ remainingDays }} day(s)</strong> after the set start date }
+          <strong>{{ remainingDays }} day(s)</strong>
           }
         </mat-hint>
         }
+        <!-- no mat-hint if data.currentState === false -->
       </mat-form-field>
     </div>
     }
@@ -228,9 +224,9 @@
         'disabled-button': isProcessing
       }"
     >
-      @if (!isProcessing) { Cancel Scheduled Submission } @else {
+      @if (isProcessing) {
       <mat-spinner class="custom-spinner" diameter="25"></mat-spinner>
-      }
+      } @else { Cancel Scheduled Submission }
     </button>
     } @else {
     <button
@@ -252,9 +248,9 @@
           (showStartDatePicker && startDate === null)
       }"
     >
-      @if (!isProcessing) { Confirm } @else {
+      @if (isProcessing) {
       <mat-spinner class="custom-spinner" diameter="25"></mat-spinner>
-      }
+      } @else { Confirm }
     </button>
     }
   </div>

--- a/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.html
+++ b/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.html
@@ -70,12 +70,16 @@
       mat-flat-button
       class="confirm-button"
       (click)="onConfirm()"
-      [disabled]="!isAnyDaySelected()"
+      [disabled]="!isAnyDaySelected() || isSaving"
       [ngClass]="{
-        'confirm-btn-disabled': !isAnyDaySelected()
+        'confirm-btn-disabled': !isAnyDaySelected() || isSaving
       }"
     >
-      Confirm
+      @if (isSaving) {
+      <mat-spinner class="custom-spinner" diameter="25"></mat-spinner>
+      } @else {
+      <span>Confirm</span>
+      }
     </button>
   </div>
 </div>

--- a/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.html
+++ b/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.html
@@ -1,7 +1,7 @@
 <div class="dialog-day-time-container">
   <!-- Dialog Title -->
   <div class="dialog-title">
-    <h2 class="title-text">Select Day & Time</h2>
+    <h2 class="title-text">Preferred Day & Time</h2>
     <span class="course-detail">For {{ courseCode }} - {{ courseTitle }}</span>
   </div>
 
@@ -22,44 +22,45 @@
       }
     </div>
 
-    <div class="time-fields">
-      <!-- Start Time Selection -->
-      <mat-form-field appearance="fill" class="dialog-field">
-        <mat-label>Start Time</mat-label>
-        <mat-select
-          [(ngModel)]="startTime"
-          (selectionChange)="onStartTimeChange()"
-          [disabled]="isWholeDay"
-        >
-          @for (time of timeOptions; track time) {
-          <mat-option [value]="time">
-            {{ time }}
-          </mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
+    <div class="time-fields-scroll-container">
+      <!-- Time Selection for Each Day -->
+      @for (day of dayButtons; track day.name) { @if (day.selected) {
+      <div class="time-fields-container">
+        <div class="day-label-wrapper">
+          <span class="day-label">{{ day.name }}</span>
+        </div>
 
-      <!-- End Time Selection -->
-      <mat-form-field appearance="fill" class="dialog-field">
-        <mat-label>End Time</mat-label>
-        <mat-select [(ngModel)]="endTime" [disabled]="isWholeDay">
-          @for (time of endTimeOptions; track time) {
-          <mat-option [value]="time">
-            {{ time }}
-          </mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
+        <div class="time-fields-wrapper">
+          <!-- Start Time Selection -->
+          <mat-form-field appearance="fill" class="dialog-field">
+            <mat-label>Start Time</mat-label>
+            <mat-select
+              [(ngModel)]="day.startTime"
+              (selectionChange)="onStartTimeChange(day)"
+            >
+              @for (time of timeOptions; track time) {
+              <mat-option [value]="time">
+                {{ time }}
+              </mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+
+          <!-- End Time Selection -->
+          <mat-form-field appearance="fill" class="dialog-field">
+            <mat-label>End Time</mat-label>
+            <mat-select [(ngModel)]="day.endTime" [disabled]="!day.startTime">
+              @for (time of day.endTimeOptions; track time) {
+              <mat-option [value]="time">
+                {{ time }}
+              </mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+        </div>
+      </div>
+      } }
     </div>
-
-    <!-- Whole Day Checkbox -->
-    <mat-checkbox
-      class="day-checkbox"
-      [(ngModel)]="isWholeDay"
-      (change)="onWholeDayChange()"
-    >
-      Whole Day (Any time is preferred)
-    </mat-checkbox>
   </div>
 
   <!-- Dialog buttons -->
@@ -69,14 +70,9 @@
       mat-flat-button
       class="confirm-button"
       (click)="onConfirm()"
-      [disabled]="
-        !isAnyDaySelected() ||
-        (!isWholeDay && (!startTime || !endTime || !isEndTimeValid()))
-      "
+      [disabled]="!isAnyDaySelected()"
       [ngClass]="{
-        'confirm-btn-disabled':
-          !isAnyDaySelected() ||
-          (!isWholeDay && (!startTime || !endTime || !isEndTimeValid()))
+        'confirm-btn-disabled': !isAnyDaySelected()
       }"
     >
       Confirm

--- a/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.html
+++ b/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.html
@@ -24,12 +24,15 @@
 
     <div class="time-fields-scroll-container">
       <!-- Time Selection for Each Day -->
-      @for (day of dayButtons; track day.name) { @if (day.selected) {
-      <div class="time-fields-container">
+      @for (day of dayButtons; track day.name) {
+      <div
+        class="time-fields-container"
+        [@showHideFieldsAnimation]="day.selected ? 'visible' : 'hidden'"
+      >
         <div class="day-label-wrapper">
           <span class="day-label">{{ day.name }}</span>
         </div>
-
+        @if (day.selected) {
         <div class="time-fields-wrapper">
           <!-- Start Time Selection -->
           <mat-form-field appearance="fill" class="dialog-field">
@@ -58,8 +61,9 @@
             </mat-select>
           </mat-form-field>
         </div>
+        }
       </div>
-      } }
+      }
     </div>
   </div>
 

--- a/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.html
+++ b/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.html
@@ -12,11 +12,8 @@
       @for (day of dayButtons; track day.name) {
       <div
         class="day-button"
-        [class.selected]="day.name === selectedDay"
-        [class.original-day]="
-          day.name === originalDay && day.name !== selectedDay
-        "
-        (click)="selectDay(day.name)"
+        [class.selected]="day.selected"
+        (click)="toggleDay(day)"
         matRipple
         [matRippleColor]="'rgba(255, 255, 255, 0.1)'"
       >
@@ -73,12 +70,12 @@
       class="confirm-button"
       (click)="onConfirm()"
       [disabled]="
-        !selectedDay ||
+        !isAnyDaySelected() ||
         (!isWholeDay && (!startTime || !endTime || !isEndTimeValid()))
       "
       [ngClass]="{
         'confirm-btn-disabled':
-          !selectedDay ||
+          !isAnyDaySelected() ||
           (!isWholeDay && (!startTime || !endTime || !isEndTimeValid()))
       }"
     >

--- a/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.scss
+++ b/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.scss
@@ -1,5 +1,9 @@
 @use "../../../styles/mixins";
 
+:host {
+  @include mixins.custom-spinner(var(--primary-text));
+}
+
 .dialog-day-time-container {
   @include mixins.flex-layout(
     $direction: column,

--- a/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.scss
+++ b/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.scss
@@ -98,17 +98,19 @@
   }
 
   .time-fields-scroll-container {
+    @include mixins.custom-scrollbar;
     flex: 1;
     overflow-y: auto;
     min-height: 0;
-    max-height: 40vh;
+    max-height: 30rem;
     padding-right: var(--spacing-xs);
-
-    @include mixins.custom-scrollbar;
   }
 
   .time-fields-container {
     @include mixins.flex-layout($direction: column, $gap: var(--spacing-xs));
+    position: relative;
+    width: 100%;
+    transform-origin: top;
 
     .day-label-wrapper {
       width: 100%;

--- a/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.scss
+++ b/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.scss
@@ -13,6 +13,7 @@
 
 .dialog-title {
   color: var(--primary-text);
+  flex-shrink: 0;
 
   .title-text {
     margin: 0;
@@ -29,10 +30,6 @@
 .dialog-content {
   height: auto;
 
-  .dialog-field {
-    width: 100%;
-  }
-
   .day-buttons-container {
     @include mixins.flex-layout(
       $justify: space-between,
@@ -44,6 +41,7 @@
     background: var(--neutral-light);
     border-radius: var(--border-radius-sm) var(--border-radius-sm) 0 0;
     border-bottom: 1px solid var(--neutral-base);
+    flex-shrink: 0;
 
     .day-button {
       @include mixins.flex-layout;
@@ -95,8 +93,34 @@
     }
   }
 
-  .time-fields {
-    @include mixins.flex-layout($gap: var(--spacing-md));
+  .time-fields-scroll-container {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+    max-height: 40vh;
+    padding-right: var(--spacing-xs);
+
+    @include mixins.custom-scrollbar;
+  }
+
+  .time-fields-container {
+    @include mixins.flex-layout($direction: column, $gap: var(--spacing-xs));
+
+    .day-label-wrapper {
+      width: 100%;
+      @include mixins.flex-layout($align: flex-start, $justify: flex-start);
+
+      .day-label {
+        color: var(--primary-text);
+        font-size: var(--font-size-sm);
+        font-weight: 500;
+      }
+    }
+
+    .time-fields-wrapper {
+      @include mixins.flex-layout($gap: var(--spacing-sm));
+      width: 100%;
+    }
   }
 }
 
@@ -106,6 +130,7 @@
     $justify: flex-end,
     $gap: var(--spacing-sm)
   );
+  flex-shrink: 0;
 
   .cancel {
     color: var(--primary-text) !important;

--- a/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.ts
+++ b/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.ts
@@ -18,25 +18,25 @@ interface DayButton {
 }
 
 @Component({
-    selector: 'app-dialog-time',
-    imports: [
-        CommonModule,
-        FormsModule,
-        MatDialogModule,
-        MatFormFieldModule,
-        MatSelectModule,
-        MatOptionModule,
-        MatButtonModule,
-        MatIconModule,
-        MatCheckboxModule,
-        MatRippleModule,
-    ],
-    templateUrl: './dialog-day-time.component.html',
-    styleUrls: ['./dialog-day-time.component.scss']
+  selector: 'app-dialog-time',
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatOptionModule,
+    MatButtonModule,
+    MatIconModule,
+    MatCheckboxModule,
+    MatRippleModule,
+  ],
+  templateUrl: './dialog-day-time.component.html',
+  styleUrls: ['./dialog-day-time.component.scss'],
 })
 export class DialogDayTimeComponent {
-  selectedDay: string = '';
-  originalDay: string = '';
+  selectedDays: string[] = [];
+  originalDays: string[] = [];
   startTime: string = '';
   endTime: string = '';
   courseCode: string = '';
@@ -63,8 +63,12 @@ export class DialogDayTimeComponent {
     this.generateTimeOptions();
 
     if (data.selectedDay) {
-      this.originalDay = data.selectedDay;
-      this.selectedDay = data.selectedDay;
+      this.originalDays = data.selectedDay;
+      this.selectedDays = data.selectedDay;
+
+      this.dayButtons.forEach((dayButton) => {
+        dayButton.selected = this.selectedDays.includes(dayButton.name);
+      });
     }
 
     if (data.selectedTime) {
@@ -88,8 +92,11 @@ export class DialogDayTimeComponent {
     }
   }
 
-  selectDay(day: string): void {
-    this.selectedDay = day;
+  toggleDay(day: DayButton): void {
+    day.selected = !day.selected;
+    this.selectedDays = this.dayButtons
+      .filter((d) => d.selected)
+      .map((d) => d.name);
   }
 
   generateTimeOptions() {
@@ -125,12 +132,12 @@ export class DialogDayTimeComponent {
   onConfirm(): void {
     if (this.isWholeDay) {
       this.dialogRef.close({
-        day: this.selectedDay,
+        days: this.selectedDays,
         time: '07:00 AM - 09:00 PM',
       });
-    } else if (this.selectedDay && this.startTime && this.endTime) {
+    } else if (this.isAnyDaySelected() && this.startTime && this.endTime) {
       this.dialogRef.close({
-        day: this.selectedDay,
+        days: this.selectedDays,
         time: `${this.startTime} - ${this.endTime}`,
       });
     }
@@ -153,5 +160,9 @@ export class DialogDayTimeComponent {
       this.startTime = '';
       this.endTime = '';
     }
+  }
+
+  isAnyDaySelected(): boolean {
+    return this.selectedDays.length > 0;
   }
 }

--- a/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.ts
+++ b/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.ts
@@ -12,6 +12,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 import { PreferencesService } from '../../core/services/faculty/preference/preferences.service';
+import { showHideFieldsAnimation } from '../../core/animations/animations';
 
 interface DayButton {
   name: string;
@@ -48,6 +49,7 @@ interface DialogData {
   templateUrl: './dialog-day-time.component.html',
   styleUrls: ['./dialog-day-time.component.scss'],
   standalone: true,
+  animations: [showHideFieldsAnimation],
 })
 export class DialogDayTimeComponent implements OnInit {
   courseCode = '';

--- a/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.ts
+++ b/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
@@ -7,14 +7,21 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { MatOptionModule } from '@angular/material/core';
 import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatRippleModule } from '@angular/material/core';
 
 interface DayButton {
   name: string;
   shortName: string;
   selected: boolean;
+  startTime: string;
+  endTime: string;
+  endTimeOptions: string[];
+}
+
+interface DialogData {
+  selectedDays: Array<{ day: string; start_time: string; end_time: string }>;
+  courseCode: string;
+  courseTitle: string;
 }
 
 @Component({
@@ -27,102 +34,141 @@ interface DayButton {
     MatSelectModule,
     MatOptionModule,
     MatButtonModule,
-    MatIconModule,
-    MatCheckboxModule,
     MatRippleModule,
   ],
   templateUrl: './dialog-day-time.component.html',
   styleUrls: ['./dialog-day-time.component.scss'],
+  standalone: true,
 })
-export class DialogDayTimeComponent {
-  selectedDays: string[] = [];
-  originalDays: string[] = [];
-  startTime: string = '';
-  endTime: string = '';
-  courseCode: string = '';
-  courseTitle: string = '';
-  isWholeDay: boolean = false;
+export class DialogDayTimeComponent implements OnInit {
+  courseCode = '';
+  courseTitle = '';
   timeOptions: string[] = [];
-  endTimeOptions: string[] = [];
+  dayButtons: DayButton[] = [];
 
-  dayButtons: DayButton[] = [
-    { name: 'Monday', shortName: 'Mon', selected: false },
-    { name: 'Tuesday', shortName: 'Tue', selected: false },
-    { name: 'Wednesday', shortName: 'Wed', selected: false },
-    { name: 'Thursday', shortName: 'Thu', selected: false },
-    { name: 'Friday', shortName: 'Fri', selected: false },
-    { name: 'Saturday', shortName: 'Sat', selected: false },
-    { name: 'Sunday', shortName: 'Sun', selected: false },
+  private readonly daysOfWeek = [
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+    'Sunday',
   ];
 
   constructor(
     public dialogRef: MatDialogRef<DialogDayTimeComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any
-  ) {
-    dialogRef.disableClose = true;
-    this.generateTimeOptions();
+    @Inject(MAT_DIALOG_DATA) public data: DialogData
+  ) {}
 
-    if (data.selectedDay) {
-      this.originalDays = data.selectedDay;
-      this.selectedDays = data.selectedDay;
+  ngOnInit(): void {
+    this.initializeDialog();
+  }
 
-      this.dayButtons.forEach((dayButton) => {
-        dayButton.selected = this.selectedDays.includes(dayButton.name);
-      });
-    }
+  // ===========================
+  // Initialization Methods
+  // ===========================
 
-    if (data.selectedTime) {
-      if (data.selectedTime === '07:00 AM - 09:00 PM') {
-        this.isWholeDay = true;
-        this.startTime = '07:00 AM';
-        this.endTime = '09:00 PM';
-      } else {
-        const [start, end] = data.selectedTime.split(' - ');
-        this.startTime = start.trim();
-        this.endTime = end.trim();
-      }
-    }
+  private initializeDialog(): void {
+    this.courseCode = this.data.courseCode || '';
+    this.courseTitle = this.data.courseTitle || '';
+    this.timeOptions = this.generateTimeOptions();
+    this.dayButtons = this.createDayButtons();
 
-    if (data.courseCode) {
-      this.courseCode = data.courseCode;
-    }
-
-    if (data.courseTitle) {
-      this.courseTitle = data.courseTitle;
+    if (this.data.selectedDays && this.data.selectedDays.length > 0) {
+      this.setSelectedDays(this.data.selectedDays);
     }
   }
 
-  toggleDay(day: DayButton): void {
-    day.selected = !day.selected;
-    this.selectedDays = this.dayButtons
-      .filter((d) => d.selected)
-      .map((d) => d.name);
+  private createDayButtons(): DayButton[] {
+    return this.daysOfWeek.map((day) => ({
+      name: day,
+      shortName: day.substring(0, 3),
+      selected: false,
+      startTime: '',
+      endTime: '',
+      endTimeOptions: [...this.timeOptions],
+    }));
   }
 
-  generateTimeOptions() {
-    this.timeOptions = [];
+  private generateTimeOptions(): string[] {
+    const options = [];
     for (let hour = 7; hour <= 21; hour++) {
       for (let minute = 0; minute < 60; minute += 30) {
         if (hour === 21 && minute === 30) break;
         const ampm = hour >= 12 ? 'PM' : 'AM';
         const hour12 = hour % 12 || 12;
-        const time = `${hour12.toString().padStart(2, '0')}:${minute
-          .toString()
-          .padStart(2, '0')} ${ampm}`;
-        this.timeOptions.push(time);
+        options.push(
+          `${hour12.toString().padStart(2, '0')}:${minute
+            .toString()
+            .padStart(2, '0')} ${ampm}`
+        );
       }
     }
-    this.endTimeOptions = [...this.timeOptions];
+    return options;
   }
 
-  onStartTimeChange() {
-    const startIndex = this.timeOptions.indexOf(this.startTime);
-    if (startIndex !== -1) {
-      this.endTimeOptions = this.timeOptions.slice(startIndex + 1);
-      if (!this.isEndTimeValid()) {
-        this.endTime = '';
+  // ===========================
+  // Data Manipulation Methods
+  // ===========================
+
+  private setSelectedDays(
+    selectedDays: Array<{ day: string; start_time: string; end_time: string }>
+  ): void {
+    if (!selectedDays) return;
+    selectedDays.forEach((selectedDay) => {
+      const dayButton = this.dayButtons.find((d) => d.name === selectedDay.day);
+      if (dayButton) {
+        if (selectedDay.start_time && selectedDay.end_time) {
+          dayButton.selected = true;
+          dayButton.startTime = this.convertTo12HourFormat(
+            selectedDay.start_time
+          );
+          dayButton.endTime = this.convertTo12HourFormat(selectedDay.end_time);
+          this.updateEndTimeOptions(dayButton);
+        } else {
+          dayButton.selected = false;
+          dayButton.startTime = '';
+          dayButton.endTime = '';
+        }
       }
+    });
+  }
+
+  private convertTo12HourFormat(time24: string): string {
+    if (!time24 || time24.includes('AM') || time24.includes('PM'))
+      return time24;
+
+    const [hours, minutes] = time24.split(':').map(Number);
+    const hour12 = hours % 12 || 12;
+    const ampm = hours < 12 || hours === 24 ? 'AM' : 'PM';
+    return `${hour12.toString().padStart(2, '0')}:${minutes
+      .toString()
+      .padStart(2, '0')} ${ampm}`;
+  }
+
+  private updateEndTimeOptions(day: DayButton): void {
+    const startIndex = this.timeOptions.indexOf(day.startTime);
+    day.endTimeOptions =
+      startIndex !== -1
+        ? this.timeOptions.slice(startIndex + 1)
+        : [...this.timeOptions];
+  }
+
+  // ===========================
+  // Event Handlers
+  // ===========================
+
+  toggleDay(day: DayButton): void {
+    day.selected = !day.selected;
+    if (!day.selected) {
+      day.startTime = '';
+      day.endTime = '';
     }
+  }
+
+  onStartTimeChange(day: DayButton): void {
+    this.updateEndTimeOptions(day);
   }
 
   onCancel(): void {
@@ -130,39 +176,27 @@ export class DialogDayTimeComponent {
   }
 
   onConfirm(): void {
-    if (this.isWholeDay) {
-      this.dialogRef.close({
-        days: this.selectedDays,
-        time: '07:00 AM - 09:00 PM',
-      });
-    } else if (this.isAnyDaySelected() && this.startTime && this.endTime) {
-      this.dialogRef.close({
-        days: this.selectedDays,
-        time: `${this.startTime} - ${this.endTime}`,
-      });
-    }
+    const selectedDays = this.dayButtons
+      .filter((day) => day.selected && day.startTime && day.endTime)
+      .map((day) => ({
+        day: day.name,
+        start_time: day.startTime,
+        end_time: day.endTime,
+      }));
+    this.dialogRef.close({ days: selectedDays });
   }
 
-  isEndTimeValid(): boolean {
-    if (!this.startTime || !this.endTime) {
-      return false;
-    }
-    const startIndex = this.timeOptions.indexOf(this.startTime);
-    const endIndex = this.timeOptions.indexOf(this.endTime);
-    return startIndex !== -1 && endIndex !== -1 && endIndex > startIndex;
-  }
-
-  onWholeDayChange(): void {
-    if (this.isWholeDay) {
-      this.startTime = '07:00 AM';
-      this.endTime = '09:00 PM';
-    } else {
-      this.startTime = '';
-      this.endTime = '';
-    }
-  }
+  // ===========================
+  // Utility Methods (Updated)
+  // ===========================
 
   isAnyDaySelected(): boolean {
-    return this.selectedDays.length > 0;
+    const anyDaySelected = this.dayButtons.some((day) => day.selected);
+    if (!anyDaySelected) {
+      return false;
+    }
+    return this.dayButtons
+      .filter((day) => day.selected)
+      .every((day) => day.startTime !== '' && day.endTime !== '');
   }
 }

--- a/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.ts
+++ b/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.ts
@@ -193,33 +193,16 @@ export class DialogDayTimeComponent implements OnInit {
           end_time: String(this.convertTo24HourFormat(day.endTime)),
         }));
 
-    const currentCourse = this.data.allSelectedCourses.find(
-        (course) => course.course_code === this.data.courseCode
-    );
-    if (currentCourse) {
-      currentCourse.preferredDays = selectedDays;
-    }
-
-    // Prepare the preference data for submission using allSelectedCourses
     const preferenceData = {
       faculty_id: parseInt(this.data.facultyId),
       active_semester_id: this.data.activeSemesterId,
-      preferences: this.data.allSelectedCourses
-          .filter((course) => course.preferredDays.length > 0)
-          .map((course) => ({
-            course_assignment_id: course.course_assignment_id,
-            preferred_days: course.preferredDays.map((day: any) => ({
-              day: day.day,
-              start_time: day.start_time,
-              end_time: day.end_time,
-            })),
-          })),
+      course_assignment_id: this.data.courseAssignmentId,
+      preferred_days: selectedDays
     };
 
-    // Submit the preferences
-    this.preferencesService.submitPreferences(preferenceData).subscribe({
+    this.preferencesService.submitSinglePreference(preferenceData).subscribe({
       next: () => {
-        this.snackBar.open('Preferences saved successfully', 'Close', {
+        this.snackBar.open('Your preferences has been saved successfully.', 'Close', {
           duration: 3000,
         });
         this.dialogRef.close({ days: selectedDays });
@@ -228,7 +211,7 @@ export class DialogDayTimeComponent implements OnInit {
         const message =
             error.status === 403 && error.error && error.error.message
                 ? error.error.message
-                : 'Error submitting preferences.';
+                : 'Error submitting preference.';
         this.snackBar.open(message, 'Close', {
           duration: 5000,
         });

--- a/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.ts
+++ b/frontend/src/app/shared/dialog-day-time/dialog-day-time.component.ts
@@ -9,6 +9,7 @@ import { MatOptionModule } from '@angular/material/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatRippleModule } from '@angular/material/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 import { PreferencesService } from '../../core/services/faculty/preference/preferences.service';
 
@@ -42,6 +43,7 @@ interface DialogData {
     MatOptionModule,
     MatButtonModule,
     MatRippleModule,
+    MatProgressSpinnerModule,
   ],
   templateUrl: './dialog-day-time.component.html',
   styleUrls: ['./dialog-day-time.component.scss'],
@@ -52,6 +54,7 @@ export class DialogDayTimeComponent implements OnInit {
   courseTitle = '';
   timeOptions: string[] = [];
   dayButtons: DayButton[] = [];
+  isSaving = false;
 
   private readonly daysOfWeek = [
     'Monday',
@@ -185,36 +188,43 @@ export class DialogDayTimeComponent implements OnInit {
   }
 
   onConfirm(): void {
+    this.isSaving = true;
     const selectedDays = this.dayButtons
-        .filter((day) => day.selected && day.startTime && day.endTime)
-        .map((day) => ({
-          day: day.name,
-          start_time: String(this.convertTo24HourFormat(day.startTime)),
-          end_time: String(this.convertTo24HourFormat(day.endTime)),
-        }));
+      .filter((day) => day.selected && day.startTime && day.endTime)
+      .map((day) => ({
+        day: day.name,
+        start_time: String(this.convertTo24HourFormat(day.startTime)),
+        end_time: String(this.convertTo24HourFormat(day.endTime)),
+      }));
 
     const preferenceData = {
       faculty_id: parseInt(this.data.facultyId),
       active_semester_id: this.data.activeSemesterId,
       course_assignment_id: this.data.courseAssignmentId,
-      preferred_days: selectedDays
+      preferred_days: selectedDays,
     };
 
     this.preferencesService.submitSinglePreference(preferenceData).subscribe({
       next: () => {
-        this.snackBar.open('Your preferences has been saved successfully.', 'Close', {
-          duration: 3000,
-        });
+        this.snackBar.open(
+          'Your preferences has been saved successfully.',
+          'Close',
+          {
+            duration: 3000,
+          }
+        );
+        this.isSaving = false;
         this.dialogRef.close({ days: selectedDays });
       },
       error: (error) => {
         const message =
-            error.status === 403 && error.error && error.error.message
-                ? error.error.message
-                : 'Error submitting preference.';
+          error.status === 403 && error.error && error.error.message
+            ? error.error.message
+            : 'Error submitting preference.';
         this.snackBar.open(message, 'Close', {
           duration: 5000,
         });
+        this.isSaving = false;
       },
     });
   }
@@ -249,7 +259,7 @@ export class DialogDayTimeComponent implements OnInit {
       return false;
     }
     return this.dayButtons
-        .filter((day) => day.selected)
-        .every((day) => day.startTime !== '' && day.endTime !== '');
+      .filter((day) => day.selected)
+      .every((day) => day.startTime !== '' && day.endTime !== '');
   }
 }

--- a/frontend/src/app/shared/dialog-pref/dialog-pref.component.html
+++ b/frontend/src/app/shared/dialog-pref/dialog-pref.component.html
@@ -107,27 +107,13 @@
             </td>
           </ng-container>
 
-          <!-- Preferred Day Column -->
-          <ng-container matColumnDef="preferredDay">
+          <!-- Preferred Day & Time Column -->
+          <ng-container matColumnDef="preferredDayTime">
             <th mat-header-cell *matHeaderCellDef class="custom-header">
-              Preferred Day
+              Preferred Day & Time
             </th>
             <td mat-cell *matCellDef="let element" class="custom-cell">
-              {{ element.preferred_day }}
-            </td>
-          </ng-container>
-
-          <!-- Preferred Time Column -->
-          <ng-container matColumnDef="preferredTime">
-            <th mat-header-cell *matHeaderCellDef class="custom-header">
-              Preferred Time
-            </th>
-            <td mat-cell *matCellDef="let element" class="custom-cell">
-              {{
-                convertToDate(element.preferred_start_time) | date : "h:mm a"
-              }}
-              -
-              {{ convertToDate(element.preferred_end_time) | date : "h:mm a" }}
+              {{ formatPreferredDaysAndTime(element) }}
             </td>
           </ng-container>
 
@@ -141,8 +127,7 @@
               'lecHours',
               'labHours',
               'units',
-              'preferredDay',
-              'preferredTime'
+              'preferredDayTime'
             ]"
           ></tr>
           <tr
@@ -156,15 +141,14 @@
                 'lecHours',
                 'labHours',
                 'units',
-                'preferredDay',
-                'preferredTime'
+                'preferredDayTime'
               ]
             "
           ></tr>
 
           <!-- No Data Row -->
           <tr *matNoDataRow>
-            <td class="no-data-cell" [attr.colspan]="8">
+            <td class="no-data-cell" [attr.colspan]="7">
               <div class="flex-cell">
                 <span mat-symbol="info"></span>
                 <span>No preferences has been submitted yet.</span>

--- a/frontend/src/app/shared/dialog-pref/dialog-pref.component.html
+++ b/frontend/src/app/shared/dialog-pref/dialog-pref.component.html
@@ -151,7 +151,7 @@
             <td class="no-data-cell" [attr.colspan]="7">
               <div class="flex-cell">
                 <span mat-symbol="info"></span>
-                <span>No preferences has been submitted yet.</span>
+                <span>No preferences have been submitted yet.</span>
               </div>
             </td>
           </tr>

--- a/frontend/src/app/shared/dialog-pref/dialog-pref.component.ts
+++ b/frontend/src/app/shared/dialog-pref/dialog-pref.component.ts
@@ -22,7 +22,7 @@ interface Course {
   lec_hours: number;
   lab_hours: number;
   units: number;
-  preferred_day: string;
+  preferred_days: string[];
   preferred_start_time: string;
   preferred_end_time: string;
 }
@@ -35,20 +35,20 @@ interface DialogPrefData {
 }
 
 @Component({
-    selector: 'app-dialog-pref',
-    imports: [
-        CommonModule,
-        FormsModule,
-        LoadingComponent,
-        MatTableModule,
-        MatButtonModule,
-        MatButtonToggleModule,
-        MatIconModule,
-        MatSymbolDirective,
-    ],
-    templateUrl: './dialog-pref.component.html',
-    styleUrls: ['./dialog-pref.component.scss'],
-    animations: [fadeAnimation]
+  selector: 'app-dialog-pref',
+  imports: [
+    CommonModule,
+    FormsModule,
+    LoadingComponent,
+    MatTableModule,
+    MatButtonModule,
+    MatButtonToggleModule,
+    MatIconModule,
+    MatSymbolDirective,
+  ],
+  templateUrl: './dialog-pref.component.html',
+  styleUrls: ['./dialog-pref.component.scss'],
+  animations: [fadeAnimation],
 })
 export class DialogPrefComponent implements OnInit {
   facultyName: string = '';
@@ -91,7 +91,7 @@ export class DialogPrefComponent implements OnInit {
               lec_hours: course.lec_hours,
               lab_hours: course.lab_hours,
               units: course.units,
-              preferred_day: course.preferred_day,
+              preferred_days: course.preferred_days,
               preferred_start_time: course.preferred_start_time,
               preferred_end_time: course.preferred_end_time,
             }));
@@ -147,5 +147,35 @@ export class DialogPrefComponent implements OnInit {
 
   convertToDate(timeString: string): Date {
     return new Date(`1970-01-01T${timeString}`);
+  }
+
+  formatPreferredDaysAndTime(course: Course): string {
+    const days = course.preferred_days.join(', ');
+    const time =
+      course.preferred_start_time === '07:00:00' &&
+      course.preferred_end_time === '21:00:00'
+        ? 'Whole Day'
+        : `${this.convertTo12HourFormat(
+            course.preferred_start_time
+          )} - ${this.convertTo12HourFormat(course.preferred_end_time)}`;
+    return `${days} (${time})`;
+  }
+
+  convertTo12HourFormat(time: string): string {
+    const [hour, minute] = time.split(':').map(Number);
+    let ampm = 'AM';
+    let hour12 = hour;
+
+    if (hour >= 12) {
+      ampm = 'PM';
+      if (hour > 12) hour12 = hour - 12;
+    }
+    if (hour === 0) {
+      hour12 = 12;
+    }
+
+    return `${hour12.toString().padStart(2, '0')}:${minute
+      .toString()
+      .padStart(2, '0')} ${ampm}`;
   }
 }

--- a/frontend/src/app/shared/dialog-pref/dialog-pref.component.ts
+++ b/frontend/src/app/shared/dialog-pref/dialog-pref.component.ts
@@ -16,21 +16,21 @@ import { PreferencesService } from '../../core/services/faculty/preference/prefe
 
 import { fadeAnimation } from '../../core/animations/animations';
 
+import jsPDF from 'jspdf';
+import 'jspdf-autotable';
+
 interface Course {
   course_code: string;
   course_title: string;
   lec_hours: number;
   lab_hours: number;
   units: number;
-  preferred_days: string[];
-  preferred_start_time: string;
-  preferred_end_time: string;
+  preferred_days: { day: string; start_time: string; end_time: string }[];
 }
 
 interface DialogPrefData {
   facultyName: string;
   faculty_id: number;
-  generatePdfFunction?: (preview: boolean) => Blob | void;
   viewOnlyTable?: boolean;
 }
 
@@ -92,13 +92,10 @@ export class DialogPrefComponent implements OnInit {
               lab_hours: course.lab_hours,
               units: course.units,
               preferred_days: course.preferred_days,
-              preferred_start_time: course.preferred_start_time,
-              preferred_end_time: course.preferred_end_time,
             }));
           }
 
           this.isLoading = false;
-
           if (!this.data.viewOnlyTable && this.selectedView === 'pdf-view') {
             this.generateAndDisplayPdf();
           }
@@ -119,48 +116,208 @@ export class DialogPrefComponent implements OnInit {
   }
 
   generateAndDisplayPdf(): void {
-    if (this.data.generatePdfFunction) {
-      const pdfBlob = this.data.generatePdfFunction(true);
-      if (pdfBlob instanceof Blob) {
-        const blobUrl = URL.createObjectURL(pdfBlob);
-        this.pdfBlobUrl =
-          this.sanitizer.bypassSecurityTrustResourceUrl(blobUrl);
-      } else {
-        console.error('generatePdfFunction did not return a Blob.');
-      }
+    const pdfBlob = this.generateFacultyPDF(false, [this.courses], true);
+    if (pdfBlob instanceof Blob) {
+      const blobUrl = URL.createObjectURL(pdfBlob);
+      this.pdfBlobUrl = this.sanitizer.bypassSecurityTrustResourceUrl(blobUrl);
     } else {
-      console.error('No generatePdfFunction provided.');
+      console.error('generateFacultyPDF did not return a Blob.');
     }
   }
 
   downloadPdf(): void {
-    if (this.data.generatePdfFunction) {
-      this.data.generatePdfFunction(false);
-    } else {
-      console.error('No generatePdfFunction provided.');
-    }
+    this.generateFacultyPDF(false, [this.courses], false);
   }
 
   closeDialog(): void {
     this.dialogRef.close();
   }
 
-  convertToDate(timeString: string): Date {
-    return new Date(`1970-01-01T${timeString}`);
+  /**
+   * Generates a PDF for faculty preferences.
+   */
+  generateFacultyPDF(
+    isAll: boolean,
+    coursesArray: Course[][],
+    showPreview: boolean = false
+  ): Blob | void {
+    const doc = new jsPDF('p', 'mm', 'legal') as any;
+    const pageWidth = doc.internal.pageSize.width;
+    const margin = 10;
+    const topMargin = 15;
+    const logoSize = 22;
+    let currentY = topMargin;
+
+    const headerFont = { font: 'times', style: 'bold', size: 12 };
+    const normalFont = { font: 'times', style: 'normal', size: 12 };
+    const centerAlign = { align: 'center' };
+
+    /**
+     * Adds the header to the PDF.
+     */
+    const addHeader = () => {
+      const leftLogoUrl =
+        'https://iantuquib.weebly.com/uploads/5/9/7/7/59776029/2881282_orig.png';
+      doc.addImage(leftLogoUrl, 'PNG', margin, 10, logoSize, logoSize);
+
+      doc.setFontSize(headerFont.size);
+      doc.setFont(headerFont.font, headerFont.style);
+      doc.text(
+        'POLYTECHNIC UNIVERSITY OF THE PHILIPPINES – TAGUIG BRANCH',
+        pageWidth / 2,
+        topMargin,
+        centerAlign
+      );
+      doc.text(
+        'Gen. Santos Ave. Upper Bicutan, Taguig City',
+        pageWidth / 2,
+        topMargin + 5,
+        centerAlign
+      );
+      doc.setFontSize(15);
+
+      if (isAll) {
+        doc.text(
+          'All Faculty Preferences Report',
+          pageWidth / 2,
+          topMargin + 15,
+          centerAlign
+        );
+      } else {
+        doc.text(
+          'Faculty Preferences Report',
+          pageWidth / 2,
+          topMargin + 15,
+          centerAlign
+        );
+      }
+
+      doc.setDrawColor(0, 0, 0);
+      doc.setLineWidth(0.5);
+      doc.line(margin, topMargin + 20, pageWidth - margin, topMargin + 20);
+
+      currentY = topMargin + 25;
+    };
+
+    addHeader();
+
+    coursesArray.forEach((courses, facultyIndex) => {
+      if (!courses || courses.length === 0) return;
+
+      doc.setFontSize(normalFont.size);
+      doc.setFont(normalFont.font, normalFont.style);
+      const facultyInfo = [
+        `Faculty Name: ${this.facultyName}`,
+        `Academic Year: ${this.academicYear}`,
+        `Semester: ${this.semesterLabel}`,
+      ];
+
+      facultyInfo.forEach((info) => {
+        doc.text(info, margin, currentY);
+        currentY += 5;
+      });
+      currentY += 5;
+
+      const courseData = courses.map((course: Course, index: number) => [
+        (index + 1).toString(),
+        course.course_code || 'N/A',
+        course.course_title || 'N/A',
+        course.lec_hours.toString(),
+        course.lab_hours.toString(),
+        course.units.toString(),
+        this.formatPreferredDaysAndTime(course),
+      ]);
+
+      // Table Configuration
+      const tableHead = [
+        [
+          '#',
+          'Course Code',
+          'Course Title',
+          'Lec',
+          'Lab',
+          'Units',
+          'Preferred Day & Time',
+        ],
+      ];
+      const tableConfig = {
+        startY: currentY,
+        head: tableHead,
+        body: courseData,
+        theme: 'grid',
+        headStyles: {
+          fillColor: [128, 0, 0],
+          textColor: [255, 255, 255],
+          fontSize: 9,
+        },
+        bodyStyles: {
+          fontSize: 8,
+          textColor: [0, 0, 0],
+        },
+        styles: {
+          lineWidth: 0.1,
+          overflow: 'linebreak',
+          cellPadding: 2,
+        },
+        columnStyles: {
+          0: { cellWidth: 10 },
+          1: { cellWidth: 30 },
+          2: { cellWidth: 50 },
+          3: { cellWidth: 13 },
+          4: { cellWidth: 13 },
+          5: { cellWidth: 13 },
+          6: { cellWidth: 50 },
+        },
+        margin: { left: margin, right: margin },
+      };
+
+      (doc as any).autoTable(tableConfig);
+
+      currentY = doc.autoTable.previous.finalY + 10;
+      if (currentY > 270) {
+        doc.addPage();
+        addHeader();
+        currentY = topMargin + 25;
+      }
+    });
+
+    const pdfBlob = doc.output('blob');
+    if (showPreview) {
+      return pdfBlob;
+    } else {
+      let fileName = 'faculty_preferences_report.pdf';
+
+      if (isAll && coursesArray.length > 0) {
+        const firstCourse = coursesArray[0][0];
+        fileName = `${this.sanitizeFileName(
+          this.facultyName
+        )}_preferences_report.pdf`;
+      }
+
+      doc.save(fileName);
+    }
   }
 
+  /**
+   * Formats the preferred days and times for display.
+   */
   formatPreferredDaysAndTime(course: Course): string {
-    const days = course.preferred_days.join(', ');
-    const time =
-      course.preferred_start_time === '07:00:00' &&
-      course.preferred_end_time === '21:00:00'
-        ? 'Whole Day'
-        : `${this.convertTo12HourFormat(
-            course.preferred_start_time
-          )} - ${this.convertTo12HourFormat(course.preferred_end_time)}`;
-    return `${days} (${time})`;
+    return course.preferred_days
+      .map((pref) => {
+        const time =
+          pref.start_time === '07:00:00' && pref.end_time === '21:00:00'
+            ? 'Whole Day'
+            : `${this.convertTo12HourFormat(
+                pref.start_time
+              )} - ${this.convertTo12HourFormat(pref.end_time)}`;
+        return `${pref.day} (${time})`;
+      })
+      .join(', ');
   }
 
+  /**
+   * Converts time from 24-hour to 12-hour format.
+   */
   convertTo12HourFormat(time: string): string {
     const [hour, minute] = time.split(':').map(Number);
     let ampm = 'AM';
@@ -177,5 +334,12 @@ export class DialogPrefComponent implements OnInit {
     return `${hour12.toString().padStart(2, '0')}:${minute
       .toString()
       .padStart(2, '0')} ${ampm}`;
+  }
+
+  /**
+   * Sanitizes the file name by replacing non-alphanumeric characters.
+   */
+  sanitizeFileName(fileName: string): string {
+    return fileName.toLowerCase().replace(/[^a-z0-9]/g, '_');
   }
 }

--- a/frontend/src/app/shared/dialog-scheduling/dialog-scheduling.component.html
+++ b/frontend/src/app/shared/dialog-scheduling/dialog-scheduling.component.html
@@ -56,12 +56,11 @@
           (click)="
             onFacultyClick(faculty, faculty.preferences[faculty.prefIndex])
           "
-          style="cursor: pointer"
           [class.selected-faculty]="
             selectedFaculty?.faculty_id === faculty.faculty_id &&
             isPreferenceSelected(faculty.preferences[faculty.prefIndex])
           "
-          
+          [@cardSwipeAnimation]="faculty.prefIndex"
           matRipple
         >
           <div

--- a/frontend/src/app/shared/dialog-scheduling/dialog-scheduling.component.html
+++ b/frontend/src/app/shared/dialog-scheduling/dialog-scheduling.component.html
@@ -5,7 +5,7 @@
       <h2 class="dialog-title suggested">
         <span mat-symbol="dynamic_form"></span> Suggested
       </h2>
-      <span class="desc">*Based on submitted preferences</span>
+      <span class="desc">Based on faculty preferences</span>
     </div>
 
     <mat-dialog-content
@@ -17,26 +17,68 @@
       <div class="no-faculty-message">
         No faculty has selected this course as their preference.
       </div>
-      } @else { @for (faculty of data.suggestedFaculty; track faculty) {
-      <div
-        class="faculty-card"
-        (click)="onFacultyClick(faculty)"
-        style="cursor: pointer"
-        [ngClass]="{ 'selected-faculty': isFacultySelected(faculty) }"
-        matRipple
-      >
-        <div
-          class="faculty-type"
-          [ngClass]="{
-            'full-time': faculty.type.includes('Full-time'),
-            'full-time-designee': faculty.type.includes('Designee'),
-            'part-time': faculty.type === 'Part-time'
-          }"
-        >
-          {{ faculty.type }}
+      } @else {
+      <!-- Outer loop for faculty -->
+      @for (faculty of data.suggestedFaculty; track faculty.faculty_id) {
+      <div class="faculty-card-wrapper">
+        <!-- Faculty Pref Navigator -->
+        @if (faculty.preferences.length > 1) {
+        <div class="faculty-pref-nav">
+          <!-- Display current and total preference count -->
+          <span class="preference-count">
+            {{ faculty.prefIndex + 1 }} of {{ faculty.preferences.length }}
+            Preferences
+          </span>
+          <!-- Navigation arrows -->
+          <div class="nav-button-container">
+            <button
+              class="pref-nav-button"
+              (click)="previousPreference(faculty)"
+              [disabled]="faculty.prefIndex === 0"
+            >
+              <mat-icon>chevron_left</mat-icon>
+            </button>
+            <button
+              class="pref-nav-button"
+              (click)="nextPreference(faculty)"
+              [disabled]="faculty.prefIndex === faculty.preferences.length - 1"
+            >
+              <mat-icon>chevron_right</mat-icon>
+            </button>
+          </div>
         </div>
-        <div class="faculty-name">{{ faculty.name }}</div>
-        <div class="faculty-pref">{{ faculty.day }}, {{ faculty.time }}</div>
+        }
+
+        <!-- Inner loop for preferences (each card) -->
+        @if (faculty.preferences[faculty.prefIndex]) {
+        <div
+          class="faculty-card"
+          (click)="
+            onFacultyClick(faculty, faculty.preferences[faculty.prefIndex])
+          "
+          style="cursor: pointer"
+          [class.selected-faculty]="
+            selectedFaculty?.faculty_id === faculty.faculty_id &&
+            isPreferenceSelected(faculty.preferences[faculty.prefIndex])
+          "
+          
+          matRipple
+        >
+          <div
+            class="faculty-type"
+            [class.full-time]="faculty.type.includes('Full-time')"
+            [class.full-time-designee]="faculty.type.includes('Designee')"
+            [class.part-time]="faculty.type === 'Part-time'"
+          >
+            {{ faculty.type }}
+          </div>
+          <div class="faculty-name">{{ faculty.name }}</div>
+          <div class="faculty-pref">
+            {{ faculty.preferences[faculty.prefIndex].day }},
+            {{ faculty.preferences[faculty.prefIndex].time }}
+          </div>
+        </div>
+        }
       </div>
       } }
     </mat-dialog-content>
@@ -106,9 +148,10 @@
             [matAutocomplete]="professorAuto"
           />
           <mat-autocomplete #professorAuto="matAutocomplete">
-            @for (professor of filteredProfessors$ | async; track professor) {
-            <mat-option [value]="professor">
-              {{ professor }}
+            @for (professor of filteredProfessors$ | async; track professor.id)
+            {
+            <mat-option [value]="professor.name">
+              {{ professor.name }}
             </mat-option>
             }
           </mat-autocomplete>

--- a/frontend/src/app/shared/dialog-scheduling/dialog-scheduling.component.scss
+++ b/frontend/src/app/shared/dialog-scheduling/dialog-scheduling.component.scss
@@ -234,12 +234,6 @@
   background-color: var(--neutral-extra);
 
   .content.faculty-list {
-    @include mixins.flex-layout(
-      $direction: column,
-      $align: stretch,
-      $justify: flex-start,
-      $gap: var(--spacing-sm)
-    );
     @include mixins.hide-scrollbar;
     margin-bottom: var(--spacing-lg);
     border-radius: var(--border-radius-sm);
@@ -248,6 +242,50 @@
     .no-faculty-message {
       opacity: var(--opacity-semi-opaque);
       font-style: italic;
+    }
+
+    .faculty-card-wrapper {
+      @include mixins.flex-layout(
+        $direction: column,
+        $align: stretch,
+        $gap: var(--spacing-xxxs)
+      );
+      margin-bottom: var(--spacing-sm);
+    }
+
+    .faculty-pref-nav {
+      @include mixins.flex-layout(
+        $align: center,
+        $justify: space-between,
+        $gap: var(--spacing-xxs)
+      );
+
+      .nav-button-container {
+        @include mixins.flex-layout;
+      }
+
+      .pref-nav-button {
+        @include mixins.flex-layout($align: center);
+        border: none;
+        outline: none;
+        background-color: transparent;
+        cursor: pointer;
+        padding: 0px;
+        border-radius: 50%;
+
+        mat-icon {
+          color: var(--neutral-base);
+        }
+
+        &:hover:not(:disabled) {
+          background-color: var(--neutral-fade);
+        }
+
+        &:disabled {
+          opacity: var(--opacity-semi-transparent);
+          cursor: not-allowed;
+        }
+      }
     }
 
     .faculty-card {

--- a/frontend/src/app/shared/dialog-scheduling/dialog-scheduling.component.scss
+++ b/frontend/src/app/shared/dialog-scheduling/dialog-scheduling.component.scss
@@ -235,9 +235,9 @@
 
   .content.faculty-list {
     @include mixins.hide-scrollbar;
-    margin-bottom: var(--spacing-lg);
+    margin-bottom: var(--spacing-xl);
     border-radius: var(--border-radius-sm);
-    overflow: visible;
+    overflow: scroll;
 
     .no-faculty-message {
       opacity: var(--opacity-semi-opaque);
@@ -248,42 +248,42 @@
       @include mixins.flex-layout(
         $direction: column,
         $align: stretch,
-        $gap: var(--spacing-xxxs)
-      );
-      margin-bottom: var(--spacing-sm);
-    }
-
-    .faculty-pref-nav {
-      @include mixins.flex-layout(
-        $align: center,
-        $justify: space-between,
         $gap: var(--spacing-xxs)
       );
+      margin-bottom: var(--spacing-sm);
 
-      .nav-button-container {
-        @include mixins.flex-layout;
-      }
+      .faculty-pref-nav {
+        @include mixins.flex-layout(
+          $align: center,
+          $justify: space-between,
+          $gap: var(--spacing-xxs)
+        );
 
-      .pref-nav-button {
-        @include mixins.flex-layout($align: center);
-        border: none;
-        outline: none;
-        background-color: transparent;
-        cursor: pointer;
-        padding: 0px;
-        border-radius: 50%;
-
-        mat-icon {
-          color: var(--neutral-base);
+        .nav-button-container {
+          @include mixins.flex-layout;
         }
 
-        &:hover:not(:disabled) {
-          background-color: var(--neutral-fade);
-        }
+        .pref-nav-button {
+          @include mixins.flex-layout($align: center);
+          border: none;
+          outline: none;
+          background-color: transparent;
+          cursor: pointer;
+          padding: 0px;
+          border-radius: 50%;
 
-        &:disabled {
-          opacity: var(--opacity-semi-transparent);
-          cursor: not-allowed;
+          mat-icon {
+            color: var(--neutral-base);
+          }
+
+          &:hover:not(:disabled) {
+            background-color: var(--neutral-fade);
+          }
+
+          &:disabled {
+            opacity: var(--opacity-semi-transparent);
+            cursor: not-allowed;
+          }
         }
       }
     }
@@ -293,10 +293,12 @@
       padding: var(--spacing-xs) var(--spacing-sm);
       border-radius: var(--border-radius-sm);
       cursor: pointer;
-      transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+      transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+        opacity 0.3s ease;
+      box-shadow: var(--shadow-level-1);
 
       &:hover {
-        transform: translateX(3px);
+        opacity: var(--opacity-semi-opaque);
       }
 
       &:active {
@@ -305,9 +307,9 @@
 
       .faculty-type {
         width: fit-content;
-        padding: 0 var(--spacing-xxs);
+        padding: 1px var(--spacing-xs);
         margin: var(--spacing-xxs) 0;
-        border-radius: var(--border-radius-xs);
+        border-radius: var(--border-radius-md);
         font-size: var(--font-size-xsx);
         font-weight: 500;
 

--- a/frontend/src/app/shared/dialog-scheduling/dialog-scheduling.component.ts
+++ b/frontend/src/app/shared/dialog-scheduling/dialog-scheduling.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormBuilder, FormGroup, Validators, ReactiveFormsModule, AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+import { FormBuilder, FormGroup, ReactiveFormsModule, AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 
 import { Observable, Subject, forkJoin } from 'rxjs';
 import { map, startWith, takeUntil, debounceTime, distinctUntilChanged } from 'rxjs/operators';
@@ -30,6 +30,24 @@ function mustMatchOption(validOptions: string[]): ValidatorFn {
   };
 }
 
+interface Preference {
+  day: string;
+  time: string;
+}
+
+interface SuggestedFaculty {
+  faculty_id: number;
+  name: string;
+  type: string;
+  preferences: Preference[];
+  prefIndex: number;
+}
+
+interface ProfessorOption {
+  id: number;
+  name: string;
+}
+
 interface DialogData {
   dayOptions: string[];
   timeOptions: string[];
@@ -37,7 +55,7 @@ interface DialogData {
   selectedProgramInfo: string;
   selectedProgramId: number;
   selectedCourseInfo: string;
-  suggestedFaculty: { name: string; type: string; day: string; time: string }[];
+  suggestedFaculty: SuggestedFaculty[];
   professorOptions: string[];
   roomOptions: string[];
   facultyOptions: Faculty[];
@@ -51,49 +69,45 @@ interface DialogData {
   schedule_id: number;
   year_level: number;
   section_id: number;
+  course_id: number;
+  preferences: any[];
 }
 
 @Component({
-    selector: 'app-dialog-scheduling',
-    imports: [
-        CommonModule,
-        MatFormFieldModule,
-        MatDialogModule,
-        MatIconModule,
-        MatInputModule,
-        MatButtonModule,
-        ReactiveFormsModule,
-        MatSelectModule,
-        MatAutocompleteModule,
-        MatRippleModule,
-        MatSnackBarModule,
-        MatProgressSpinnerModule,
-        MatSymbolDirective,
-    ],
-    templateUrl: './dialog-scheduling.component.html',
-    styleUrls: ['./dialog-scheduling.component.scss'],
-    animations: [cardEntranceSide]
+  selector: 'app-dialog-scheduling',
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatDialogModule,
+    MatIconModule,
+    MatInputModule,
+    MatButtonModule,
+    ReactiveFormsModule,
+    MatSelectModule,
+    MatAutocompleteModule,
+    MatRippleModule,
+    MatSnackBarModule,
+    MatProgressSpinnerModule,
+    MatSymbolDirective,
+  ],
+  templateUrl: './dialog-scheduling.component.html',
+  styleUrls: ['./dialog-scheduling.component.scss'],
+  animations: [cardEntranceSide],
 })
 export class DialogSchedulingComponent implements OnInit, OnDestroy {
   scheduleForm!: FormGroup;
-  filteredProfessors$!: Observable<string[]>;
+  filteredProfessors$!: Observable<ProfessorOption[]>;
   filteredRooms$!: Observable<string[]>;
   hasConflicts = false;
   isLoading = false;
   conflictMessage: string = '';
-
-  private destroy$ = new Subject<void>();
-
-  selectedFaculty: {
-    name: string;
-    type: string;
-    day: string;
-    time: string;
-  } | null = null;
+  selectedFaculty: SuggestedFaculty | null = null;
 
   dayButtons: { name: string; shortName: string }[] = [];
   selectedDay: string = '';
   originalDay: string = '';
+
+  private destroy$ = new Subject<void>();
 
   constructor(
     private fb: FormBuilder,
@@ -112,12 +126,6 @@ export class DialogSchedulingComponent implements OnInit, OnDestroy {
     this.populateExistingSchedule();
     this.setupConflictDetection();
     this.setupCustomValidators();
-
-    this.selectedDay = this.scheduleForm.get('day')!.value || '';
-    this.originalDay = this.selectedDay;
-    this.scheduleForm.get('day')!.valueChanges
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(day => this.selectedDay = day);
   }
 
   ngOnDestroy(): void {
@@ -135,7 +143,7 @@ export class DialogSchedulingComponent implements OnInit, OnDestroy {
       Saturday: 'Sat',
       Sunday: 'Sun',
     };
-    this.dayButtons = this.data.dayOptions.map(day => ({
+    this.dayButtons = this.data.dayOptions.map((day) => ({
       name: day,
       shortName: dayShortNames[day] || day.substring(0, 3),
     }));
@@ -298,14 +306,12 @@ export class DialogSchedulingComponent implements OnInit, OnDestroy {
   }
 
   private setupCustomValidators(): void {
-    this.scheduleForm.get('professor')?.setValidators([
-      // Validators.required,
-      mustMatchOption(this.data.professorOptions),
-    ]);
-    this.scheduleForm.get('room')?.setValidators([
-      // Validators.required,
-      mustMatchOption(this.data.roomOptions),
-    ]);
+    this.scheduleForm
+      .get('professor')
+      ?.setValidators([mustMatchOption(this.data.professorOptions)]);
+    this.scheduleForm
+      .get('room')
+      ?.setValidators([mustMatchOption(this.data.roomOptions)]);
 
     this.scheduleForm.get('professor')?.updateValueAndValidity();
     this.scheduleForm.get('room')?.updateValueAndValidity();
@@ -325,6 +331,10 @@ export class DialogSchedulingComponent implements OnInit, OnDestroy {
       room: room !== 'Not set' ? room : '',
     });
 
+    // Set selectedDay immediately after patching the form
+    this.selectedDay = this.scheduleForm.get('day')!.value || '';
+    this.originalDay = this.selectedDay;
+
     if (startTime && startTime !== 'Not set') {
       this.updateEndTimeOptions(startTime);
     }
@@ -343,6 +353,7 @@ export class DialogSchedulingComponent implements OnInit, OnDestroy {
     this.data.endTimeOptions = [...this.data.timeOptions];
     this.selectedDay = '';
     this.originalDay = '';
+    this.selectedFaculty = null;
   }
 
   public onAssign(): void {
@@ -420,19 +431,15 @@ export class DialogSchedulingComponent implements OnInit, OnDestroy {
     });
   }
 
-  public onFacultyClick(faculty: {
-    name: string;
-    type: string;
-    day: string;
-    time: string;
-  }): void {
+  public onFacultyClick(
+    faculty: SuggestedFaculty,
+    preference: Preference
+  ): void {
     this.selectedFaculty = faculty;
 
-    const day = faculty.day;
-
-    const [startTime, endTime] = faculty.time
-      .split(' - ')
-      .map((time) => time.trim());
+    const day = preference.day;
+    const time = preference.time;
+    const [startTime, endTime] = time.split(' - ').map((t) => t.trim());
 
     this.scheduleForm.patchValue({
       day: day,
@@ -446,23 +453,51 @@ export class DialogSchedulingComponent implements OnInit, OnDestroy {
     this.scheduleForm.markAllAsTouched();
   }
 
+  nextPreference(faculty: SuggestedFaculty): void {
+    faculty.prefIndex = (faculty.prefIndex + 1) % faculty.preferences.length;
+  }
+
+  previousPreference(faculty: SuggestedFaculty): void {
+    faculty.prefIndex =
+      (faculty.prefIndex - 1 + faculty.preferences.length) %
+      faculty.preferences.length;
+  }
+
   /*** Autocomplete and Filtering ***/
 
   private setupAutocomplete(): void {
-    this.filteredProfessors$ = this.setupFilter(
-      'professor',
-      this.data.professorOptions
+    const professorOptions: ProfessorOption[] = this.data.professorOptions.map(
+      (name, index) => ({
+        id: index,
+        name: name,
+      })
     );
+
+    this.filteredProfessors$ = this.setupFilter('professor', professorOptions);
     this.filteredRooms$ = this.setupFilter('room', this.data.roomOptions);
   }
 
   private setupFilter(
     controlName: string,
-    options: string[]
-  ): Observable<string[]> {
+    options: string[] | ProfessorOption[]
+  ): Observable<any> {
     return this.scheduleForm.get(controlName)!.valueChanges.pipe(
       startWith(''),
-      map((value) => this.filterOptions(value, options))
+      map((value) =>
+        Array.isArray(options) && typeof options[0] === 'string'
+          ? this.filterOptions(value, options as string[])
+          : this.filterProfessorOptions(value, options as ProfessorOption[])
+      )
+    );
+  }
+
+  private filterProfessorOptions(
+    value: string | null,
+    options: ProfessorOption[]
+  ): ProfessorOption[] {
+    const filterValue = (value || '').toLowerCase();
+    return options.filter((option) =>
+      option.name.toLowerCase().includes(filterValue)
     );
   }
 
@@ -507,7 +542,7 @@ export class DialogSchedulingComponent implements OnInit, OnDestroy {
     if (!time) {
       return null;
     }
-  
+
     const [timePart, period] = time.split(' ');
     let [hours, minutes] = timePart.split(':').map(Number);
 
@@ -523,22 +558,14 @@ export class DialogSchedulingComponent implements OnInit, OnDestroy {
     return `${formattedHours}:${formattedMinutes}:00`;
   }
 
-  private handleError(message: string) {
-    return (error: any): void => {
-      console.error(`${message}:`, error);
-      this.snackBar.open(`${message}. Please try again.`, 'Close', {
-        duration: 3000,
-      });
-    };
-  }
-
-  public isFacultySelected(faculty: {
-    name: string;
-    type: string;
-    day: string;
-    time: string;
-  }): boolean {
-    return this.selectedFaculty === faculty;
+  public isPreferenceSelected(preference: Preference): boolean {
+    return (
+      this.scheduleForm.get('day')?.value === preference.day &&
+      this.scheduleForm.get('startTime')?.value +
+        ' - ' +
+        this.scheduleForm.get('endTime')?.value ===
+        preference.time
+    );
   }
 
   public selectDay(dayName: string): void {

--- a/frontend/src/app/shared/dialog-scheduling/dialog-scheduling.component.ts
+++ b/frontend/src/app/shared/dialog-scheduling/dialog-scheduling.component.ts
@@ -20,7 +20,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { SchedulingService } from '../../core/services/admin/scheduling/scheduling.service';
 import { Faculty, Room } from '../../core/models/scheduling.model';
 
-import { cardEntranceSide } from '../../core/animations/animations';
+import { cardEntranceSide, cardSwipeAnimation } from '../../core/animations/animations';
 
 function mustMatchOption(validOptions: string[]): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
@@ -41,6 +41,7 @@ interface SuggestedFaculty {
   type: string;
   preferences: Preference[];
   prefIndex: number;
+  animating: boolean;
 }
 
 interface ProfessorOption {
@@ -92,7 +93,7 @@ interface DialogData {
   ],
   templateUrl: './dialog-scheduling.component.html',
   styleUrls: ['./dialog-scheduling.component.scss'],
-  animations: [cardEntranceSide],
+  animations: [cardEntranceSide, cardSwipeAnimation],
 })
 export class DialogSchedulingComponent implements OnInit, OnDestroy {
   scheduleForm!: FormGroup;
@@ -126,6 +127,10 @@ export class DialogSchedulingComponent implements OnInit, OnDestroy {
     this.populateExistingSchedule();
     this.setupConflictDetection();
     this.setupCustomValidators();
+
+    this.data.suggestedFaculty.forEach(
+      (faculty) => (faculty.animating = false)
+    );
   }
 
   ngOnDestroy(): void {
@@ -454,13 +459,33 @@ export class DialogSchedulingComponent implements OnInit, OnDestroy {
   }
 
   nextPreference(faculty: SuggestedFaculty): void {
+    // If an animation is currently running, ignore the click
+    if (faculty.animating) {
+      return;
+    }
+
+    faculty.animating = true;
     faculty.prefIndex = (faculty.prefIndex + 1) % faculty.preferences.length;
+
+    setTimeout(() => {
+      faculty.animating = false;
+    }, 600);
   }
 
   previousPreference(faculty: SuggestedFaculty): void {
+    // If an animation is currently running, ignore the click
+    if (faculty.animating) {
+      return;
+    }
+
+    faculty.animating = true;
     faculty.prefIndex =
       (faculty.prefIndex - 1 + faculty.preferences.length) %
       faculty.preferences.length;
+
+    setTimeout(() => {
+      faculty.animating = false;
+    }, 600);
   }
 
   /*** Autocomplete and Filtering ***/

--- a/frontend/src/app/shared/table-header/table-header.component.ts
+++ b/frontend/src/app/shared/table-header/table-header.component.ts
@@ -24,7 +24,6 @@ export interface InputField {
 
 @Component({
   selector: 'app-table-header',
-  standalone: true,
   imports: [
     CommonModule,
     MatIconModule,


### PR DESCRIPTION
Good day, FLSS team. This update brings a **major refactor to the faculty preferences submission** which I have been working on this week. To understand why this update is significant, here's our current preferences submission process:

1. Faculty adds a course in the table (e.g. "Intro to Computing")
2. Faculty sets their preferred day and time for this course (e.g. Monday, 07:30 AM to 12:30 PM)

   >In the current process, the faculty can only set a 1:1 relation to a course and the preferred schedule
3. Faculty clicks "Confirm", and the preference data is saved temporarily in the browser memory
4. Faculty may want to add another course and their preferred schedule for it, and
5. Faculty clicks "Submit Preferences" and all the preferences data are submitted


As you can see, there are already **two major flaws** in the process. First:


During our conversation with our defense panelists, one of the key issues they raised is the limitation of preferences submission, which is a 1:1 relation between course and schedule. Though at first I thought this was how it was supposed to be, we also had a conversation with our client/s, the branch director and HAP admin, who also stated that they had also noticed this limitation, though not really bothered by it since it's just a "preference" and their job for scheduling remains unaffected.

However, as we approach the testing phase of our capstone project, after using the system myself these past weeks, I realized that from the perspective of the faculty members (not the director or HAP na gagawa ng scheduling) who will use our system, the current process we have is indeed very limiting. In fact, they may even prefer the manual process where they can indicate any schedule they want. Unlike satin na if you select this X course then you should only choose this X day and X time. And if this happens, then the chance of our system being abandoned goes very likely *more than it already does*.

This week, after working with our API integration with the ECRS system, I decided to give this refactor a shot, because this requires drastic changes across the backend (APIs & database particularly) and frontend, and I wasn't sure if it would work. Below are the results.

### Faculty can now select multiple preferred schedules for a single course. This gives them a highly flexible way to submit their preferences to the administrator.

https://github.com/user-attachments/assets/7ec60a0d-6748-4a0e-8314-4e4325f1c504

### No more bulk preference submission (easier and safer way)
Another major flaw in the process is the bulk preference submission. This was okay at first back when our process was that after the faculty submission, their submission is disabled right away. But now that the preferences are freely submitted and modified within a period of time, this just introduces unnecessary steps, and even unsafe because what if they forget to click the submit button? Or if the browser unexpectedly reloads, or closes? or any interruption? Then all their efforts in adding their preferences are wasted. This is not a good user experience. In the new process, when user clicks "Confirm" in the `dialog-day-time-button`, their changes are saved right away.

### With these changes, our view preferences feature in both table and PDF are also updated

https://github.com/user-attachments/assets/65e2f97f-7af2-4afa-850d-3ec5447132e0

### When scheduling, since the faculty can now have multiple preferred schedules for a course, the administrator can now navigate through a faculty's preferences (animations only look laggy here due to the screen recording)

https://github.com/user-attachments/assets/a7e93579-aa25-4450-a9bd-d5145c46ec15

In summary, the new process now looks like this:

1. Faculty adds a course to the table (e.g. "Intro to Computing")
2. Faculty sets their preferred schedules for this course (e.g. Mon, 07:30 AM to 12:30 PM, Fri 07:30 AM to 12:30 AM, etc.)
3. Faculty clicks "Confirm", and the preference data is saved in the database.

While this new process still ties the course and the preferred day and time strictly to one another which is not the case with the current manual process, hence, giving the latter an arguably better flexibility, I think the new process implemented still significantly enhances the user experience for faculty.

With these changes, our system is now more ready to be presented to the faculty members of PUP Taguig in the pre-production testing phase soon.

And as usual, kindly test the new changes to your local and let me know if there are any issues or bugs - you can open an issue here on GitHub or through our message channels. Thanks.