### PR TITLE
Add "Sunday" column for each table in PDF

### DIFF
--- a/frontend/src/app/core/components/admin/reports/report-faculty/report-faculty.component.ts
+++ b/frontend/src/app/core/components/admin/reports/report-faculty/report-faculty.component.ts
@@ -519,6 +519,7 @@ export class ReportFacultyComponent
       'Thursday',
       'Friday',
       'Saturday',
+      'Sunday',
     ];
     const dayColumnWidth = (pageWidth - margin * 2) / days.length;
     const pageHeight = doc.internal.pageSize.height;

--- a/frontend/src/app/core/components/admin/reports/report-programs/report-programs.component.ts
+++ b/frontend/src/app/core/components/admin/reports/report-programs/report-programs.component.ts
@@ -659,6 +659,7 @@ export class ReportProgramsComponent implements OnInit {
       'Thursday',
       'Friday',
       'Saturday',
+      'Sunday'
     ];
     const dayColumnWidth = (pageWidth - margin * 2) / days.length;
     const pageHeight = doc.internal.pageSize.height;
@@ -726,7 +727,7 @@ export class ReportProgramsComponent implements OnInit {
         );
 
       daySchedule.forEach((item: any) => {
-        const boxHeight = 35;
+        const boxHeight = 40;
 
         if (yPosition + boxHeight > maxContentHeight) {
           days.forEach((_, i) => {

--- a/frontend/src/app/core/components/admin/reports/report-rooms/report-rooms.component.ts
+++ b/frontend/src/app/core/components/admin/reports/report-rooms/report-rooms.component.ts
@@ -376,6 +376,7 @@ export class ReportRoomsComponent
       'Thursday',
       'Friday',
       'Saturday',
+      'Sunday',
     ];
     const dayColumnWidth = (pageWidth - margin * 2) / days.length;
     const pageHeight = doc.internal.pageSize.height;


### PR DESCRIPTION
**Good Eve FLSS Team!** Upon testing and reviewing our system, I noticed a minor bug in generating PDFs in the official reports component. When I tried to schedule on a Sunday and view it in the PDF, the table did not include a Sunday column, resulting in the Sunday schedule not being displayed. This pull request includes the necessary changes to the official reports. Now, each report will include a Sunday column when generating PDFs. Thank you!